### PR TITLE
refactor: extract type system and create modular crate architecture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "example-instructions"
+version = "0.0.2"
+dependencies = [
+ "wit-bindgen",
+ "wit-component",
+]
+
+[[package]]
 name = "foldhash"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,6 +363,7 @@ dependencies = [
  "gravity-go",
  "gravity-wit",
  "heck",
+ "indexmap",
  "pretty_assertions",
  "wit-bindgen-core",
  "wit-component",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -65,9 +71,24 @@ dependencies = [
  "clap",
  "genco",
  "rustversion",
- "wit-bindgen",
+ "wit-bindgen 0.42.1",
  "wit-bindgen-core",
  "wit-component",
+]
+
+[[package]]
+name = "augurs-outlier"
+version = "0.10.1"
+source = "git+https://github.com/grafana/augurs?branch=rand-0.9#631ce6ae7abf3724416248e92595833b37ce1b0e"
+dependencies = [
+ "itertools 0.14.0",
+ "roots",
+ "rustc-hash",
+ "rv",
+ "serde",
+ "thiserror",
+ "tinyvec",
+ "tracing",
 ]
 
 [[package]]
@@ -81,6 +102,12 @@ name = "bitflags"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "clap"
@@ -116,6 +143,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,7 +164,7 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 name = "example-basic"
 version = "0.0.2"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.42.1",
  "wit-component",
 ]
 
@@ -133,7 +172,7 @@ dependencies = [
 name = "example-iface-method-returns-string"
 version = "0.0.2"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.42.1",
  "wit-component",
 ]
 
@@ -141,7 +180,25 @@ dependencies = [
 name = "example-instructions"
 version = "0.0.2"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.42.1",
+ "wit-component",
+]
+
+[[package]]
+name = "example-outlier"
+version = "0.0.2"
+dependencies = [
+ "augurs-outlier",
+ "getrandom",
+ "wit-bindgen 0.42.1",
+ "wit-component",
+]
+
+[[package]]
+name = "example-records"
+version = "0.0.2"
+dependencies = [
+ "wit-bindgen 0.42.1",
  "wit-component",
 ]
 
@@ -263,11 +320,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -301,6 +372,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -313,16 +402,111 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "libc"
+version = "0.2.176"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
+
+[[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
 name = "log"
 version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+ "libm",
+]
 
 [[package]]
 name = "once_cell"
@@ -341,6 +525,15 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "prettyplease"
@@ -371,16 +564,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
+dependencies = [
+ "num-traits",
+ "rand",
+]
+
+[[package]]
 name = "relative-path"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
+name = "roots"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "082f11ffa03bbef6c2c6ea6bea1acafaade2fd9050ae0234ab44a2153742b058"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rv"
+version = "0.18.1"
+source = "git+https://github.com/sd2k/rv?branch=bump-rand-dependency#8309905835dd867cce2765e3dc151c54354e6dc0"
+dependencies = [
+ "doc-comment",
+ "itertools 0.13.0",
+ "lru",
+ "num",
+ "num-traits",
+ "rand",
+ "rand_distr",
+ "special",
+]
 
 [[package]]
 name = "ryu"
@@ -442,6 +707,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
+name = "special"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b89cf0d71ae639fdd8097350bfac415a41aabf1d5ddd356295fdc95f09760382"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -456,6 +730,72 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tracing"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]
@@ -475,6 +815,24 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen 0.46.0",
+]
 
 [[package]]
 name = "wasm-encoder"
@@ -594,6 +952,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
 name = "wit-bindgen-core"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -682,3 +1046,63 @@ dependencies = [
  "unicode-xid",
  "wasmparser",
 ]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[patch.unused]]
+name = "argmin"
+version = "0.10.0"
+source = "git+https://github.com/argmin-rs/argmin?branch=main#314af533752e7b95e7b8303604f16b4b330c42f1"
+
+[[patch.unused]]
+name = "argmin-math"
+version = "0.4.0"
+source = "git+https://github.com/argmin-rs/argmin?branch=main#314af533752e7b95e7b8303604f16b4b330c42f1"
+
+[[patch.unused]]
+name = "cap-rand"
+version = "3.4.4"
+source = "git+https://github.com/sd2k/cap-std?branch=bump-rand#31f05b9705b947c6e375996f854d6dc8d6f968be"
+
+[[patch.unused]]
+name = "changepoint"
+version = "0.14.2"
+source = "git+https://github.com/sd2k/changepoint?branch=patched-deps-to-bump-rand#1f197a8aac1730a7c3a43fbafddacf739b275beb"
+
+[[patch.unused]]
+name = "statrs"
+version = "0.18.0"
+source = "git+https://github.com/RobertJacobsonCDC/statrs?branch=update_rand_to_09#245b98522e28a2701f0798c61d21c498a9847612"
+
+[[patch.unused]]
+name = "wasmtime"
+version = "38.0.0"
+source = "git+https://github.com/sd2k/wasmtime?branch=bump-rand#dcc8dd117c6d4c18a30afd3991ff1c7b84faa23e"
+
+[[patch.unused]]
+name = "wasmtime-wasi"
+version = "38.0.0"
+source = "git+https://github.com/sd2k/wasmtime?branch=bump-rand#dcc8dd117c6d4c18a30afd3991ff1c7b84faa23e"
+
+[[patch.unused]]
+name = "wasmtime-wasi-io"
+version = "38.0.0"
+source = "git+https://github.com/sd2k/wasmtime?branch=bump-rand#dcc8dd117c6d4c18a30afd3991ff1c7b84faa23e"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,18 +3,6 @@
 version = 4
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,7 +172,7 @@ name = "example-basic"
 version = "0.0.2"
 dependencies = [
  "wit-bindgen 0.42.1",
- "wit-component 0.230.0",
+ "wit-component",
 ]
 
 [[package]]
@@ -192,7 +180,7 @@ name = "example-iface-method-returns-string"
 version = "0.0.2"
 dependencies = [
  "wit-bindgen 0.42.1",
- "wit-component 0.230.0",
+ "wit-component",
 ]
 
 [[package]]
@@ -200,7 +188,7 @@ name = "example-instructions"
 version = "0.0.2"
 dependencies = [
  "wit-bindgen 0.42.1",
- "wit-component 0.230.0",
+ "wit-component",
 ]
 
 [[package]]
@@ -210,7 +198,7 @@ dependencies = [
  "augurs-outlier",
  "getrandom",
  "wit-bindgen 0.42.1",
- "wit-component 0.230.0",
+ "wit-component",
 ]
 
 [[package]]
@@ -218,7 +206,7 @@ name = "example-records"
 version = "0.0.2"
 dependencies = [
  "wit-bindgen 0.42.1",
- "wit-component 0.230.0",
+ "wit-component",
 ]
 
 [[package]]
@@ -362,10 +350,8 @@ dependencies = [
  "gravity-wit",
  "heck",
  "rustversion",
- "wasmparser 0.220.1",
- "wit-bindgen-core 0.36.0",
- "wit-component 0.220.1",
- "wit-parser 0.220.1",
+ "wit-bindgen-core",
+ "wit-component",
 ]
 
 [[package]]
@@ -378,9 +364,8 @@ dependencies = [
  "gravity-wit",
  "heck",
  "pretty_assertions",
- "wit-bindgen-core 0.36.0",
- "wit-component 0.220.1",
- "wit-parser 0.220.1",
+ "wit-bindgen-core",
+ "wit-component",
 ]
 
 [[package]]
@@ -399,19 +384,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "pretty_assertions",
- "wit-bindgen-core 0.36.0",
- "wit-component 0.220.1",
- "wit-parser 0.220.1",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "serde",
+ "wit-bindgen-core",
+ "wit-component",
 ]
 
 [[package]]
@@ -444,7 +418,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown",
  "serde",
 ]
 
@@ -479,12 +453,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
-name = "leb128"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
-
-[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -514,7 +482,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown 0.15.2",
+ "hashbrown",
 ]
 
 [[package]]
@@ -806,15 +774,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
-name = "spdx"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e17e880bafaeb362a7b751ec46bdc5b61445a188f80e0606e68167cd540fa3"
-dependencies = [
- "smallvec",
-]
-
-[[package]]
 name = "special"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -925,12 +884,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
 name = "wasi"
 version = "0.14.7+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -950,38 +903,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.220.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e913f9242315ca39eff82aee0e19ee7a372155717ff0eb082c741e435ce25ed1"
-dependencies = [
- "leb128",
- "wasmparser 0.220.1",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.230.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4349d0943718e6e434b51b9639e876293093dca4b96384fb136ab5bd5ce6660"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.230.0",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.220.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "185dfcd27fa5db2e6a23906b54c28199935f71d9a27a1a27b3a88d6fee2afae7"
-dependencies = [
- "anyhow",
- "indexmap",
- "serde",
- "serde_derive",
- "serde_json",
- "spdx",
- "wasm-encoder 0.220.1",
- "wasmparser 0.220.1",
+ "wasmparser",
 ]
 
 [[package]]
@@ -992,22 +919,8 @@ checksum = "1a52e010df5494f4289ccc68ce0c2a8c17555225a5e55cc41b98f5ea28d0844b"
 dependencies = [
  "anyhow",
  "indexmap",
- "wasm-encoder 0.230.0",
- "wasmparser 0.230.0",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.220.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d07b6a3b550fefa1a914b6d54fc175dd11c3392da11eee604e6ffc759805d25"
-dependencies = [
- "ahash",
- "bitflags",
- "hashbrown 0.14.5",
- "indexmap",
- "semver",
- "serde",
+ "wasm-encoder",
+ "wasmparser",
 ]
 
 [[package]]
@@ -1017,7 +930,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "808198a69b5a0535583370a51d459baa14261dfab04800c4864ee9e1a14346ed"
 dependencies = [
  "bitflags",
- "hashbrown 0.15.2",
+ "hashbrown",
  "indexmap",
  "semver",
 ]
@@ -1113,24 +1026,13 @@ checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "wit-bindgen-core"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b632a5a0fa2409489bd49c9e6d99fcc61bb3d4ce9d1907d44662e75a28c71172"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser 0.220.1",
-]
-
-[[package]]
-name = "wit-bindgen-core"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e35e550f614e16db196e051d22b0d4c94dd6f52c90cb1016240f71b9db332631"
 dependencies = [
  "anyhow",
  "heck",
- "wit-parser 0.230.0",
+ "wit-parser",
 ]
 
 [[package]]
@@ -1155,9 +1057,9 @@ dependencies = [
  "indexmap",
  "prettyplease",
  "syn",
- "wasm-metadata 0.230.0",
- "wit-bindgen-core 0.42.1",
- "wit-component 0.230.0",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
 ]
 
 [[package]]
@@ -1171,27 +1073,8 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "wit-bindgen-core 0.42.1",
+ "wit-bindgen-core",
  "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.220.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b505603761ed400c90ed30261f44a768317348e49f1864e82ecdc3b2744e5627"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder 0.220.1",
- "wasm-metadata 0.220.1",
- "wasmparser 0.220.1",
- "wit-parser 0.220.1",
 ]
 
 [[package]]
@@ -1207,28 +1090,10 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.230.0",
- "wasm-metadata 0.230.0",
- "wasmparser 0.230.0",
- "wit-parser 0.230.0",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.220.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae2a7999ed18efe59be8de2db9cb2b7f84d88b27818c79353dfc53131840fe1a"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser 0.220.1",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
 ]
 
 [[package]]
@@ -1246,7 +1111,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.230.0",
+ "wasmparser",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,6 +363,7 @@ dependencies = [
  "heck",
  "rustversion",
  "wasmparser 0.220.1",
+ "wit-bindgen-core 0.36.0",
  "wit-component 0.220.1",
  "wit-parser 0.220.1",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,6 +389,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "gravity2"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "genco",
+ "gravity-codegen",
+ "gravity-go",
+ "heck",
+ "hex",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -404,6 +419,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "id-arena"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -65,18 +77,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
-name = "arcjet-gravity"
-version = "0.0.2"
-dependencies = [
- "clap",
- "genco",
- "rustversion",
- "wit-bindgen 0.42.1",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
 name = "augurs-outlier"
 version = "0.10.1"
 source = "git+https://github.com/grafana/augurs?branch=rand-0.9#631ce6ae7abf3724416248e92595833b37ce1b0e"
@@ -116,6 +116,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7eac00902d9d136acd712710d71823fb8ac8004ca445a89e73a41d45aa712931"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -131,6 +132,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_derive"
+version = "4.5.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "clap_lex"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,6 +154,12 @@ name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "doc-comment"
@@ -165,7 +184,7 @@ name = "example-basic"
 version = "0.0.2"
 dependencies = [
  "wit-bindgen 0.42.1",
- "wit-component",
+ "wit-component 0.230.0",
 ]
 
 [[package]]
@@ -173,7 +192,7 @@ name = "example-iface-method-returns-string"
 version = "0.0.2"
 dependencies = [
  "wit-bindgen 0.42.1",
- "wit-component",
+ "wit-component 0.230.0",
 ]
 
 [[package]]
@@ -181,7 +200,7 @@ name = "example-instructions"
 version = "0.0.2"
 dependencies = [
  "wit-bindgen 0.42.1",
- "wit-component",
+ "wit-component 0.230.0",
 ]
 
 [[package]]
@@ -191,7 +210,7 @@ dependencies = [
  "augurs-outlier",
  "getrandom",
  "wit-bindgen 0.42.1",
- "wit-component",
+ "wit-component 0.230.0",
 ]
 
 [[package]]
@@ -199,7 +218,7 @@ name = "example-records"
 version = "0.0.2"
 dependencies = [
  "wit-bindgen 0.42.1",
- "wit-component",
+ "wit-component 0.230.0",
 ]
 
 [[package]]
@@ -332,6 +351,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "gravity"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "genco",
+ "gravity-codegen",
+ "gravity-go",
+ "gravity-wit",
+ "heck",
+ "rustversion",
+ "wasmparser 0.220.1",
+ "wit-component 0.220.1",
+ "wit-parser 0.220.1",
+]
+
+[[package]]
+name = "gravity-codegen"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "genco",
+ "gravity-go",
+ "gravity-wit",
+ "heck",
+ "pretty_assertions",
+ "wit-bindgen-core 0.36.0",
+ "wit-component 0.220.1",
+ "wit-parser 0.220.1",
+]
+
+[[package]]
+name = "gravity-go"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "genco",
+ "heck",
+ "pretty_assertions",
+]
+
+[[package]]
+name = "gravity-wit"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "pretty_assertions",
+ "wit-bindgen-core 0.36.0",
+ "wit-component 0.220.1",
+ "wit-parser 0.220.1",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "serde",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -361,7 +443,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.2",
  "serde",
 ]
 
@@ -396,6 +478,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
+name = "leb128"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -425,7 +513,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -533,6 +621,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
 ]
 
 [[package]]
@@ -702,9 +800,18 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "spdx"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e17e880bafaeb362a7b751ec46bdc5b61445a188f80e0606e68167cd540fa3"
+dependencies = [
+ "smallvec",
+]
 
 [[package]]
 name = "special"
@@ -817,6 +924,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "wasi"
 version = "0.14.7+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -836,12 +949,38 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
+version = "0.220.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e913f9242315ca39eff82aee0e19ee7a372155717ff0eb082c741e435ce25ed1"
+dependencies = [
+ "leb128",
+ "wasmparser 0.220.1",
+]
+
+[[package]]
+name = "wasm-encoder"
 version = "0.230.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4349d0943718e6e434b51b9639e876293093dca4b96384fb136ab5bd5ce6660"
 dependencies = [
  "leb128fmt",
- "wasmparser",
+ "wasmparser 0.230.0",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.220.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "185dfcd27fa5db2e6a23906b54c28199935f71d9a27a1a27b3a88d6fee2afae7"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "spdx",
+ "wasm-encoder 0.220.1",
+ "wasmparser 0.220.1",
 ]
 
 [[package]]
@@ -852,8 +991,22 @@ checksum = "1a52e010df5494f4289ccc68ce0c2a8c17555225a5e55cc41b98f5ea28d0844b"
 dependencies = [
  "anyhow",
  "indexmap",
- "wasm-encoder",
- "wasmparser",
+ "wasm-encoder 0.230.0",
+ "wasmparser 0.230.0",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.220.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d07b6a3b550fefa1a914b6d54fc175dd11c3392da11eee604e6ffc759805d25"
+dependencies = [
+ "ahash",
+ "bitflags",
+ "hashbrown 0.14.5",
+ "indexmap",
+ "semver",
+ "serde",
 ]
 
 [[package]]
@@ -863,7 +1016,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "808198a69b5a0535583370a51d459baa14261dfab04800c4864ee9e1a14346ed"
 dependencies = [
  "bitflags",
- "hashbrown",
+ "hashbrown 0.15.2",
  "indexmap",
  "semver",
 ]
@@ -959,13 +1112,24 @@ checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "wit-bindgen-core"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b632a5a0fa2409489bd49c9e6d99fcc61bb3d4ce9d1907d44662e75a28c71172"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser 0.220.1",
+]
+
+[[package]]
+name = "wit-bindgen-core"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e35e550f614e16db196e051d22b0d4c94dd6f52c90cb1016240f71b9db332631"
 dependencies = [
  "anyhow",
  "heck",
- "wit-parser",
+ "wit-parser 0.230.0",
 ]
 
 [[package]]
@@ -990,9 +1154,9 @@ dependencies = [
  "indexmap",
  "prettyplease",
  "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
+ "wasm-metadata 0.230.0",
+ "wit-bindgen-core 0.42.1",
+ "wit-component 0.230.0",
 ]
 
 [[package]]
@@ -1006,8 +1170,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "wit-bindgen-core",
+ "wit-bindgen-core 0.42.1",
  "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.220.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b505603761ed400c90ed30261f44a768317348e49f1864e82ecdc3b2744e5627"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder 0.220.1",
+ "wasm-metadata 0.220.1",
+ "wasmparser 0.220.1",
+ "wit-parser 0.220.1",
 ]
 
 [[package]]
@@ -1023,10 +1206,28 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
+ "wasm-encoder 0.230.0",
+ "wasm-metadata 0.230.0",
+ "wasmparser 0.230.0",
+ "wit-parser 0.230.0",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.220.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae2a7999ed18efe59be8de2db9cb2b7f84d88b27818c79353dfc53131840fe1a"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.220.1",
 ]
 
 [[package]]
@@ -1044,8 +1245,14 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser",
+ "wasmparser 0.230.0",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,15 @@
 [workspace]
-resolver = "3"
+resolver = "2"
 members = ["cmd/*", "crates/*", "examples/*"]
+
+[workspace.dependencies]
+# Core dependencies with consistent versions
+wit-bindgen-core = "=0.42.1"
+wit-component = "=0.230.0"
+genco = "=0.17.10"
+anyhow = "1.0"
+heck = "0.5"
+clap = { version = "=4.5.47", features = ["derive"] }
 
 [patch.crates-io]
 # rand 0.9 merged into main, waiting for a new release.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,23 @@
 [workspace]
 resolver = "3"
 members = ["cmd/*", "examples/*"]
+
+[patch.crates-io]
+# rand 0.9 merged into main, waiting for a new release.
+argmin = { git = "https://github.com/argmin-rs/argmin", branch = "main" }
+argmin-math = { git = "https://github.com/argmin-rs/argmin", branch = "main" }
+
+# Depends on rv PR and release (see below).
+changepoint = { git = "https://github.com/sd2k/changepoint", branch = "patched-deps-to-bump-rand" }
+# See PR at https://github.com/promised-ai/rv/pull/48.
+rv = { git = "https://github.com/sd2k/rv", branch = "bump-rand-dependency" }
+
+# See PR at https://github.com/statrs-dev/statrs/pull/331.
+statrs = { git = "https://github.com/RobertJacobsonCDC/statrs", branch = "update_rand_to_09" }
+
+# Depends on cap-rand PR/release (see below).
+wasmtime = { git = "https://github.com/sd2k/wasmtime", branch = "bump-rand" }
+wasmtime-wasi = { git = "https://github.com/sd2k/wasmtime", branch = "bump-rand" }
+wasmtime-wasi-io = { git = "https://github.com/sd2k/wasmtime", branch = "bump-rand" }
+# See PR at https://github.com/bytecodealliance/cap-std/pull/394
+cap-rand = { git = "https://github.com/sd2k/cap-std", branch = "bump-rand" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "3"
-members = ["cmd/*", "examples/*"]
+members = ["cmd/*", "crates/*", "examples/*"]
 
 [patch.crates-io]
 # rand 0.9 merged into main, waiting for a new release.

--- a/cmd/gravity/Cargo.toml
+++ b/cmd/gravity/Cargo.toml
@@ -11,14 +11,12 @@ path = "src/main.rs"
 gravity-go = { path = "../../crates/gravity-go" }
 gravity-codegen = { path = "../../crates/gravity-codegen" }
 gravity-wit = { path = "../../crates/gravity-wit" }
-genco = { version = "0.17" }
-wit-bindgen-core = "0.36"
-wit-parser = "0.220"
-wit-component = "0.220"
-wasmparser = "0.220"
-anyhow = "1.0"
-clap = { version = "4.5", features = ["derive"] }
-heck = "0.5"
+genco = { workspace = true }
+wit-bindgen-core = { workspace = true }
+wit-component = { workspace = true }
+anyhow = { workspace = true }
+clap = { workspace = true }
+heck = { workspace = true }
 
 [build-dependencies]
 rustversion = "=1.0.22"

--- a/cmd/gravity/Cargo.toml
+++ b/cmd/gravity/Cargo.toml
@@ -12,6 +12,7 @@ gravity-go = { path = "../../crates/gravity-go" }
 gravity-codegen = { path = "../../crates/gravity-codegen" }
 gravity-wit = { path = "../../crates/gravity-wit" }
 genco = { version = "0.17" }
+wit-bindgen-core = "0.36"
 wit-parser = "0.220"
 wit-component = "0.220"
 wasmparser = "0.220"

--- a/cmd/gravity/Cargo.toml
+++ b/cmd/gravity/Cargo.toml
@@ -1,29 +1,23 @@
 [package]
-authors = ["The Arcjet team"]
-categories = ["wasm"]
-default-run = "gravity"
-name = "arcjet-gravity"
-version = "0.0.2"
-edition = "2024"
-license = "Apache-2.0"
-repository = "https://github.com/arcjet/gravity"
-description = """
-Gravity is a host generator for WebAssembly Components. It currently targets Wazero, a zero dependency WebAssembly runtime for Go.
-"""
-build = "build.rs"
+name = "gravity"
+version = "0.1.0"
+edition = "2021"
 
 [[bin]]
 name = "gravity"
 path = "src/main.rs"
 
 [dependencies]
-clap = "=4.5.47"
-genco = "=0.17.10"
-wit-bindgen-core = "=0.42.1"
-wit-component = "=0.230.0"
-
-[dev-dependencies]
-wit-bindgen = "=0.42.1"
+gravity-go = { path = "../../crates/gravity-go" }
+gravity-codegen = { path = "../../crates/gravity-codegen" }
+gravity-wit = { path = "../../crates/gravity-wit" }
+genco = { version = "0.17" }
+wit-parser = "0.220"
+wit-component = "0.220"
+wasmparser = "0.220"
+anyhow = "1.0"
+clap = { version = "4.5", features = ["derive"] }
+heck = "0.5"
 
 [build-dependencies]
 rustversion = "=1.0.22"

--- a/cmd/gravity/src/main.rs
+++ b/cmd/gravity/src/main.rs
@@ -1421,7 +1421,16 @@ impl Bindgen for Func {
             }
             Instruction::CoreF32FromF32 => todo!("implement instruction: {inst:?}"),
             Instruction::CoreF64FromF64 => todo!("implement instruction: {inst:?}"),
-            Instruction::S8FromI32 => todo!("implement instruction: {inst:?}"),
+            Instruction::S8FromI32 => {
+                let tmp = self.tmp();
+                let result = &format!("result{tmp}");
+                let operand = &operands[0];
+                quote_in! { self.body =>
+                    $['\r']
+                    $result := int8($operand)
+                };
+                results.push(Operand::SingleValue(result.into()));
+            }
             Instruction::U8FromI32 => todo!("implement instruction: {inst:?}"),
             Instruction::S16FromI32 => todo!("implement instruction: {inst:?}"),
             Instruction::U16FromI32 => todo!("implement instruction: {inst:?}"),

--- a/cmd/gravity/src/main.rs
+++ b/cmd/gravity/src/main.rs
@@ -499,20 +499,22 @@ impl Bindgen for Func {
                 // at the types and converting with proper guards in place
                 quote_in! { self.body =>
                     $['\r']
-                    $raw, $err := i.module.ExportedFunction($(quoted(*name))).Call(ctx, $(for op in operands.iter() join (, ) => uint64($op)))
                     $(match &self.result {
                         GoResult::Anon(GoType::ValueOrError(typ)) => {
+                            $raw, $err := i.module.ExportedFunction($(quoted(*name))).Call(ctx, $(for op in operands.iter() join (, ) => uint64($op)))
                             if $err != nil {
                                 var $default $(typ.as_ref())
                                 return $default, $err
                             }
                         }
                         GoResult::Anon(GoType::Error) => {
+                            $raw, $err := i.module.ExportedFunction($(quoted(*name))).Call(ctx, $(for op in operands.iter() join (, ) => uint64($op)))
                             if $err != nil {
                                 return $err
                             }
                         }
                         GoResult::Anon(_) | GoResult::Empty => {
+                            _, $err := i.module.ExportedFunction($(quoted(*name))).Call(ctx, $(for op in operands.iter() join (, ) => uint64($op)))
                             $(comment(&["The return type doesn't contain an error so we panic if one is encountered"]))
                             if $err != nil {
                                 panic($err)
@@ -538,7 +540,10 @@ impl Bindgen for Func {
                         }()
                     })
 
-                    $ret := $raw[0]
+                    $(match &self.result {
+                        GoResult::Anon(_) => $ret := $raw[0],
+                        GoResult::Empty => (),
+                    })
                 };
                 match self.result {
                     GoResult::Empty => (),

--- a/cmd/gravity/src/main.rs
+++ b/cmd/gravity/src/main.rs
@@ -515,8 +515,9 @@ impl Bindgen for Func {
                         }
                         GoResult::Anon(_) => {
                             $raw, $err := i.module.ExportedFunction($(quoted(*name))).Call(ctx, $(for op in operands.iter() join (, ) => uint64($op)))
+                            $(comment(&["The return type doesn't contain an error so we panic if one is encountered"]))
                             if $err != nil {
-                                return $err
+                                panic($err)
                             }
                         }
                         GoResult::Empty => {

--- a/cmd/gravity/src/main.rs
+++ b/cmd/gravity/src/main.rs
@@ -1409,7 +1409,16 @@ impl Bindgen for Func {
             Instruction::I32FromChar => todo!("implement instruction: {inst:?}"),
             Instruction::I64FromU64 => todo!("implement instruction: {inst:?}"),
             Instruction::I64FromS64 => todo!("implement instruction: {inst:?}"),
-            Instruction::I32FromS32 => todo!("implement instruction: {inst:?}"),
+            Instruction::I32FromS32 => {
+                let tmp = self.tmp();
+                let value = format!("value{tmp}");
+                let operand = &operands[0];
+                quote_in! { self.body =>
+                    $['\r']
+                    $(&value) := $wazero_api_encode_i32($operand)
+                }
+                results.push(Operand::SingleValue(value))
+            }
             // All of these values should fit in Go's `int32` type which allows a safe cast
             Instruction::I32FromU16
             | Instruction::I32FromS16
@@ -1466,7 +1475,16 @@ impl Bindgen for Func {
                 };
                 results.push(Operand::SingleValue(result.into()));
             }
-            Instruction::S32FromI32 => todo!("implement instruction: {inst:?}"),
+            Instruction::S32FromI32 => {
+                let tmp = self.tmp();
+                let result = &format!("result{tmp}");
+                let operand = &operands[0];
+                quote_in! { self.body =>
+                    $['\r']
+                    $result := $wazero_api_decode_i32($operand)
+                };
+                results.push(Operand::SingleValue(result.into()));
+            }
             Instruction::S64FromI64 => todo!("implement instruction: {inst:?}"),
             Instruction::U64FromI64 => todo!("implement instruction: {inst:?}"),
             Instruction::CharFromI32 => todo!("implement instruction: {inst:?}"),

--- a/cmd/gravity/src/main.rs
+++ b/cmd/gravity/src/main.rs
@@ -513,7 +513,13 @@ impl Bindgen for Func {
                                 return $err
                             }
                         }
-                        GoResult::Anon(_) | GoResult::Empty => {
+                        GoResult::Anon(_) => {
+                            $raw, $err := i.module.ExportedFunction($(quoted(*name))).Call(ctx, $(for op in operands.iter() join (, ) => uint64($op)))
+                            if $err != nil {
+                                return $err
+                            }
+                        }
+                        GoResult::Empty => {
                             _, $err := i.module.ExportedFunction($(quoted(*name))).Call(ctx, $(for op in operands.iter() join (, ) => uint64($op)))
                             $(comment(&["The return type doesn't contain an error so we panic if one is encountered"]))
                             if $err != nil {

--- a/cmd/gravity/src/main.rs
+++ b/cmd/gravity/src/main.rs
@@ -640,7 +640,7 @@ impl Bindgen for Func {
                 let operand = &operands[0];
                 quote_in! { self.body =>
                     $['\r']
-                    $result := $wazero_api_decode_u32($operand)
+                    $result := $wazero_api_decode_u32(uint64($operand))
                 };
                 results.push(Operand::SingleValue(result.into()));
             }
@@ -1409,16 +1409,168 @@ impl Bindgen for Func {
             Instruction::I32Load8S { .. } => todo!("implement instruction: {inst:?}"),
             Instruction::I32Load16U { .. } => todo!("implement instruction: {inst:?}"),
             Instruction::I32Load16S { .. } => todo!("implement instruction: {inst:?}"),
-            Instruction::I64Load { .. } => todo!("implement instruction: {inst:?}"),
-            Instruction::F32Load { .. } => todo!("implement instruction: {inst:?}"),
-            Instruction::F64Load { .. } => todo!("implement instruction: {inst:?}"),
+            Instruction::I64Load { offset } => {
+                // TODO(#58): Support additional ArchitectureSize
+                let offset = offset.size_wasm32();
+                let tmp = self.tmp();
+                let value = &format!("value{tmp}");
+                let ok = &format!("ok{tmp}");
+                let default = &format!("default{tmp}");
+                let operand = &operands[0];
+                quote_in! { self.body =>
+                    $['\r']
+                    $value, $ok := i.module.Memory().ReadUint64Le(uint32($operand + $offset))
+                    $(match &self.result {
+                        GoResult::Anon(GoType::ValueOrError(typ)) => {
+                            if !$ok {
+                                var $default $(typ.as_ref())
+                                return $default, $errors_new("failed to read i64 from memory")
+                            }
+                        }
+                        GoResult::Anon(GoType::Error) => {
+                            if !$ok {
+                                return $errors_new("failed to read i64 from memory")
+                            }
+                        }
+                        GoResult::Anon(_) | GoResult::Empty => {
+                            $(comment(&["The return type doesn't contain an error so we panic if one is encountered"]))
+                            if !$ok {
+                                panic($errors_new("failed to read i64 from memory"))
+                            }
+                        }
+                    })
+                };
+                results.push(Operand::SingleValue(value.into()));
+            }
+            Instruction::F32Load { offset } => {
+                // TODO(#58): Support additional ArchitectureSize
+                let offset = offset.size_wasm32();
+                let tmp = self.tmp();
+                let value = &format!("value{tmp}");
+                let ok = &format!("ok{tmp}");
+                let default = &format!("default{tmp}");
+                let operand = &operands[0];
+                quote_in! { self.body =>
+                    $['\r']
+                    $value, $ok := i.module.Memory().ReadUint64Le(uint32($operand + $offset))
+                    $(match &self.result {
+                        GoResult::Anon(GoType::ValueOrError(typ)) => {
+                            if !$ok {
+                                var $default $(typ.as_ref())
+                                return $default, $errors_new("failed to read f64 from memory")
+                            }
+                        }
+                        GoResult::Anon(GoType::Error) => {
+                            if !$ok {
+                                return $errors_new("failed to read f64 from memory")
+                            }
+                        }
+                        GoResult::Anon(_) | GoResult::Empty => {
+                            $(comment(&["The return type doesn't contain an error so we panic if one is encountered"]))
+                            if !$ok {
+                                panic($errors_new("failed to read f64 from memory"))
+                            }
+                        }
+                    })
+                };
+                results.push(Operand::SingleValue(value.into()));
+            }
+            Instruction::F64Load { offset } => {
+                // TODO(#58): Support additional ArchitectureSize
+                let offset = offset.size_wasm32();
+                let tmp = self.tmp();
+                let value = &format!("value{tmp}");
+                let ok = &format!("ok{tmp}");
+                let default = &format!("default{tmp}");
+                let operand = &operands[0];
+                quote_in! { self.body =>
+                    $['\r']
+                    $value, $ok := i.module.Memory().ReadUint64Le(uint32($operand + $offset))
+                    $(match &self.result {
+                        GoResult::Anon(GoType::ValueOrError(typ)) => {
+                            if !$ok {
+                                var $default $(typ.as_ref())
+                                return $default, $errors_new("failed to read f64 from memory")
+                            }
+                        }
+                        GoResult::Anon(GoType::Error) => {
+                            if !$ok {
+                                return $errors_new("failed to read f64 from memory")
+                            }
+                        }
+                        GoResult::Anon(_) | GoResult::Empty => {
+                            $(comment(&["The return type doesn't contain an error so we panic if one is encountered"]))
+                            if !$ok {
+                                panic($errors_new("failed to read f64 from memory"))
+                            }
+                        }
+                    })
+                };
+                results.push(Operand::SingleValue(value.into()));
+            }
             Instruction::I32Store16 { .. } => todo!("implement instruction: {inst:?}"),
             Instruction::I64Store { .. } => todo!("implement instruction: {inst:?}"),
-            Instruction::F32Store { .. } => todo!("implement instruction: {inst:?}"),
-            Instruction::F64Store { .. } => todo!("implement instruction: {inst:?}"),
+            Instruction::F32Store { offset } => {
+                // TODO(#58): Support additional ArchitectureSize
+                let offset = offset.size_wasm32();
+                let tag = &operands[0];
+                let ptr = &operands[1];
+                match &self.direction {
+                    Direction::Export => {
+                        quote_in! { self.body =>
+                            $['\r']
+                            i.module.Memory().WriteUint64Le($ptr+$offset, $tag)
+                        }
+                    }
+                    Direction::Import { .. } => {
+                        quote_in! { self.body =>
+                            $['\r']
+                            mod.Memory().WriteUint64Le($ptr+$offset, $tag)
+                        }
+                    }
+                }
+            }
+            Instruction::F64Store { offset } => {
+                // TODO(#58): Support additional ArchitectureSize
+                let offset = offset.size_wasm32();
+                let tag = &operands[0];
+                let ptr = &operands[1];
+                match &self.direction {
+                    Direction::Export => {
+                        quote_in! { self.body =>
+                            $['\r']
+                            i.module.Memory().WriteUint64Le($ptr+$offset, $tag)
+                        }
+                    }
+                    Direction::Import { .. } => {
+                        quote_in! { self.body =>
+                            $['\r']
+                            mod.Memory().WriteUint64Le($ptr+$offset, $tag)
+                        }
+                    }
+                }
+            }
             Instruction::I32FromChar => todo!("implement instruction: {inst:?}"),
-            Instruction::I64FromU64 => todo!("implement instruction: {inst:?}"),
-            Instruction::I64FromS64 => todo!("implement instruction: {inst:?}"),
+            Instruction::I64FromU64 => {
+                let tmp = self.tmp();
+                let value = format!("value{tmp}");
+                let operand = &operands[0];
+                quote_in! { self.body =>
+                    $['\r']
+                    $(&value) := int64($operand)
+                }
+                results.push(Operand::SingleValue(value.into()));
+            }
+            Instruction::I64FromS64 => {
+                let tmp = self.tmp();
+                let value = format!("value{tmp}");
+                let operand = &operands[0];
+                quote_in! { self.body =>
+                    $['\r']
+                    $(&value) := $operand
+                }
+                results.push(Operand::SingleValue(value.into()));
+            }
             Instruction::I32FromS32 => {
                 let tmp = self.tmp();
                 let value = format!("value{tmp}");
@@ -1468,6 +1620,7 @@ impl Bindgen for Func {
                 let result = &format!("result{tmp}");
                 let operand = &operands[0];
                 quote_in! { self.body =>
+                    $(comment(&["S8FromI32"]))
                     $['\r']
                     $result := int8($wazero_api_decode_i32($operand))
                 };
@@ -1478,6 +1631,7 @@ impl Bindgen for Func {
                 let result = &format!("result{tmp}");
                 let operand = &operands[0];
                 quote_in! { self.body =>
+                    $(comment(&["U8FromI32"]))
                     $['\r']
                     $result := uint8($wazero_api_decode_u32($operand))
                 };
@@ -1514,7 +1668,17 @@ impl Bindgen for Func {
                 results.push(Operand::SingleValue(result.into()));
             }
             Instruction::S64FromI64 => todo!("implement instruction: {inst:?}"),
-            Instruction::U64FromI64 => todo!("implement instruction: {inst:?}"),
+            Instruction::U64FromI64 => {
+                let tmp = self.tmp();
+                let value = format!("value{tmp}");
+                let operand = &operands[0];
+                quote_in! { self.body =>
+                    $(comment(&["U64FromI64"]))
+                    $['\r']
+                    $(&value) := uint64($operand)
+                }
+                results.push(Operand::SingleValue(value.into()));
+            }
             Instruction::CharFromI32 => todo!("implement instruction: {inst:?}"),
             Instruction::F32FromCoreF32 => {
                 let tmp = self.tmp();

--- a/cmd/gravity/src/main.rs
+++ b/cmd/gravity/src/main.rs
@@ -1408,7 +1408,16 @@ impl Bindgen for Func {
             Instruction::I32FromS32 => todo!("implement instruction: {inst:?}"),
             Instruction::I32FromU16 => todo!("implement instruction: {inst:?}"),
             Instruction::I32FromS16 => todo!("implement instruction: {inst:?}"),
-            Instruction::I32FromU8 => todo!("implement instruction: {inst:?}"),
+            Instruction::I32FromU8 => {
+                let tmp = self.tmp();
+                let value = format!("value{tmp}");
+                let operand = &operands[0];
+                quote_in! { self.body =>
+                    $['\r']
+                    $(&value) := int32($operand)
+                }
+                results.push(Operand::SingleValue(value))
+            }
             Instruction::I32FromS8 => {
                 let tmp = self.tmp();
                 let value = format!("value{tmp}");
@@ -1431,7 +1440,16 @@ impl Bindgen for Func {
                 };
                 results.push(Operand::SingleValue(result.into()));
             }
-            Instruction::U8FromI32 => todo!("implement instruction: {inst:?}"),
+            Instruction::U8FromI32 => {
+                let tmp = self.tmp();
+                let result = &format!("result{tmp}");
+                let operand = &operands[0];
+                quote_in! { self.body =>
+                    $['\r']
+                    $result := uint8($operand)
+                };
+                results.push(Operand::SingleValue(result.into()));
+            }
             Instruction::S16FromI32 => todo!("implement instruction: {inst:?}"),
             Instruction::U16FromI32 => todo!("implement instruction: {inst:?}"),
             Instruction::S32FromI32 => todo!("implement instruction: {inst:?}"),

--- a/cmd/gravity/src/main.rs
+++ b/cmd/gravity/src/main.rs
@@ -1394,7 +1394,16 @@ impl Bindgen for Func {
             Instruction::I32FromU16 => todo!("implement instruction: {inst:?}"),
             Instruction::I32FromS16 => todo!("implement instruction: {inst:?}"),
             Instruction::I32FromU8 => todo!("implement instruction: {inst:?}"),
-            Instruction::I32FromS8 => todo!("implement instruction: {inst:?}"),
+            Instruction::I32FromS8 => {
+                let tmp = self.tmp();
+                let value = format!("value{tmp}");
+                let operand = &operands[0];
+                quote_in! { self.body =>
+                    $['\r']
+                    $(&value) := int32($operand)
+                }
+                results.push(Operand::SingleValue(value))
+            }
             Instruction::CoreF32FromF32 => todo!("implement instruction: {inst:?}"),
             Instruction::CoreF64FromF64 => todo!("implement instruction: {inst:?}"),
             Instruction::S8FromI32 => todo!("implement instruction: {inst:?}"),

--- a/cmd/gravity/src/main.rs
+++ b/cmd/gravity/src/main.rs
@@ -540,7 +540,10 @@ impl Bindgen for Func {
 
                     $ret := $raw[0]
                 };
-                results.push(Operand::SingleValue(ret.into()));
+                match self.result {
+                    GoResult::Empty => (),
+                    GoResult::Anon(_) => results.push(Operand::SingleValue(ret.into())),
+                }
             }
             Instruction::I32Load8U { offset } => {
                 // TODO(#58): Support additional ArchitectureSize

--- a/cmd/gravity/src/main.rs
+++ b/cmd/gravity/src/main.rs
@@ -425,6 +425,10 @@ impl Bindgen for Func {
         let wazero_api_encode_i32 = &go::import("github.com/tetratelabs/wazero/api", "EncodeI32");
         let wazero_api_decode_u32 = &go::import("github.com/tetratelabs/wazero/api", "DecodeU32");
         let wazero_api_encode_u32 = &go::import("github.com/tetratelabs/wazero/api", "EncodeU32");
+        let wazero_api_decode_f32 = &go::import("github.com/tetratelabs/wazero/api", "DecodeF32");
+        let wazero_api_encode_f32 = &go::import("github.com/tetratelabs/wazero/api", "EncodeF32");
+        let wazero_api_decode_f64 = &go::import("github.com/tetratelabs/wazero/api", "DecodeF64");
+        let wazero_api_encode_f64 = &go::import("github.com/tetratelabs/wazero/api", "EncodeF64");
 
         // println!("instruction: {inst:?}, operands: {operands:?}");
 
@@ -1439,8 +1443,26 @@ impl Bindgen for Func {
                 }
                 results.push(Operand::SingleValue(value))
             }
-            Instruction::CoreF32FromF32 => todo!("implement instruction: {inst:?}"),
-            Instruction::CoreF64FromF64 => todo!("implement instruction: {inst:?}"),
+            Instruction::CoreF32FromF32 => {
+                let tmp = self.tmp();
+                let result = &format!("result{tmp}");
+                let operand = &operands[0];
+                quote_in! { self.body =>
+                    $['\r']
+                    $result := $wazero_api_encode_f32($operand)
+                };
+                results.push(Operand::SingleValue(result.into()));
+            }
+            Instruction::CoreF64FromF64 => {
+                let tmp = self.tmp();
+                let result = &format!("result{tmp}");
+                let operand = &operands[0];
+                quote_in! { self.body =>
+                    $['\r']
+                    $result := $wazero_api_encode_f64($operand)
+                };
+                results.push(Operand::SingleValue(result.into()));
+            }
             Instruction::S8FromI32 => {
                 let tmp = self.tmp();
                 let result = &format!("result{tmp}");
@@ -1494,8 +1516,26 @@ impl Bindgen for Func {
             Instruction::S64FromI64 => todo!("implement instruction: {inst:?}"),
             Instruction::U64FromI64 => todo!("implement instruction: {inst:?}"),
             Instruction::CharFromI32 => todo!("implement instruction: {inst:?}"),
-            Instruction::F32FromCoreF32 => todo!("implement instruction: {inst:?}"),
-            Instruction::F64FromCoreF64 => todo!("implement instruction: {inst:?}"),
+            Instruction::F32FromCoreF32 => {
+                let tmp = self.tmp();
+                let result = &format!("result{tmp}");
+                let operand = &operands[0];
+                quote_in! { self.body =>
+                    $['\r']
+                    $result := $wazero_api_decode_f32($operand)
+                };
+                results.push(Operand::SingleValue(result.into()));
+            }
+            Instruction::F64FromCoreF64 => {
+                let tmp = self.tmp();
+                let result = &format!("result{tmp}");
+                let operand = &operands[0];
+                quote_in! { self.body =>
+                    $['\r']
+                    $result := $wazero_api_decode_f64($operand)
+                };
+                results.push(Operand::SingleValue(result.into()));
+            }
             Instruction::TupleLower { .. } => todo!("implement instruction: {inst:?}"),
             Instruction::TupleLift { .. } => todo!("implement instruction: {inst:?}"),
             Instruction::FlagsLower { .. } => todo!("implement instruction: {inst:?}"),

--- a/cmd/gravity/src/main.rs
+++ b/cmd/gravity/src/main.rs
@@ -1422,6 +1422,7 @@ impl Bindgen for Func {
             }
             Instruction::CoreF32FromF32 => todo!("implement instruction: {inst:?}"),
             Instruction::CoreF64FromF64 => todo!("implement instruction: {inst:?}"),
+            // TODO: Validate the Go cast truncates the upper bits in the I32
             Instruction::S8FromI32 => {
                 let tmp = self.tmp();
                 let result = &format!("result{tmp}");
@@ -1432,6 +1433,7 @@ impl Bindgen for Func {
                 };
                 results.push(Operand::SingleValue(result.into()));
             }
+            // TODO: Validate the Go cast truncates the upper bits in the I32
             Instruction::U8FromI32 => {
                 let tmp = self.tmp();
                 let result = &format!("result{tmp}");
@@ -1442,6 +1444,7 @@ impl Bindgen for Func {
                 };
                 results.push(Operand::SingleValue(result.into()));
             }
+            // TODO: Validate the Go cast truncates the upper bits in the I32
             Instruction::S16FromI32 => {
                 let tmp = self.tmp();
                 let result = &format!("result{tmp}");
@@ -1452,6 +1455,7 @@ impl Bindgen for Func {
                 };
                 results.push(Operand::SingleValue(result.into()));
             }
+            // TODO: Validate the Go cast truncates the upper bits in the I32
             Instruction::U16FromI32 => {
                 let tmp = self.tmp();
                 let result = &format!("result{tmp}");

--- a/cmd/gravity/src/main.rs
+++ b/cmd/gravity/src/main.rs
@@ -1497,8 +1497,8 @@ impl Bindgen for Func {
             Instruction::FutureLift { .. } => todo!("implement instruction: {inst:?}"),
             Instruction::StreamLower { .. } => todo!("implement instruction: {inst:?}"),
             Instruction::StreamLift { .. } => todo!("implement instruction: {inst:?}"),
-            Instruction::ErrorContextLower { .. } => todo!("implement instruction: {inst:?}"),
-            Instruction::ErrorContextLift { .. } => todo!("implement instruction: {inst:?}"),
+            Instruction::ErrorContextLower => todo!("implement instruction: {inst:?}"),
+            Instruction::ErrorContextLift => todo!("implement instruction: {inst:?}"),
             Instruction::AsyncTaskReturn { .. } => todo!("implement instruction: {inst:?}"),
             Instruction::DropHandle { .. } => todo!("implement instruction: {inst:?}"),
             Instruction::Flush { amt } => {

--- a/cmd/gravity/src/main.rs
+++ b/cmd/gravity/src/main.rs
@@ -1669,7 +1669,7 @@ impl Bindgen for Func {
                     $['\r']
                     $(&value) := int64($operand)
                 }
-                results.push(Operand::SingleValue(value.into()));
+                results.push(Operand::SingleValue(value));
             }
             Instruction::I64FromS64 => {
                 let tmp = self.tmp();
@@ -1679,7 +1679,7 @@ impl Bindgen for Func {
                     $['\r']
                     $(&value) := $operand
                 }
-                results.push(Operand::SingleValue(value.into()));
+                results.push(Operand::SingleValue(value));
             }
             Instruction::I32FromS32 => {
                 let tmp = self.tmp();
@@ -1786,7 +1786,7 @@ impl Bindgen for Func {
                     $['\r']
                     $(&value) := uint64($operand)
                 }
-                results.push(Operand::SingleValue(value.into()));
+                results.push(Operand::SingleValue(value));
             }
             Instruction::CharFromI32 => todo!("implement instruction: {inst:?}"),
             Instruction::F32FromCoreF32 => {

--- a/cmd/gravity/src/main.rs
+++ b/cmd/gravity/src/main.rs
@@ -424,6 +424,7 @@ impl Bindgen for Func {
         let wazero_api_decode_i32 = &go::import("github.com/tetratelabs/wazero/api", "DecodeI32");
         let wazero_api_encode_i32 = &go::import("github.com/tetratelabs/wazero/api", "EncodeI32");
         let wazero_api_decode_u32 = &go::import("github.com/tetratelabs/wazero/api", "DecodeU32");
+        let wazero_api_encode_u32 = &go::import("github.com/tetratelabs/wazero/api", "EncodeU32");
 
         // println!("instruction: {inst:?}, operands: {operands:?}");
 
@@ -620,9 +621,14 @@ impl Bindgen for Func {
                 results.push(Operand::SingleValue(value))
             }
             Instruction::I32FromU32 => {
-                // It seems like this isn't needed because Wazero works with Go's uint32 type
+                let tmp = self.tmp();
+                let result = &format!("result{tmp}");
                 let operand = &operands[0];
-                results.push(operand.clone());
+                quote_in! { self.body =>
+                    $['\r']
+                    $result := $wazero_api_encode_u32($operand)
+                };
+                results.push(Operand::SingleValue(result.into()));
             }
             Instruction::U32FromI32 => {
                 let tmp = self.tmp();
@@ -630,7 +636,7 @@ impl Bindgen for Func {
                 let operand = &operands[0];
                 quote_in! { self.body =>
                     $['\r']
-                    $result := uint32($operand)
+                    $result := $wazero_api_decode_u32($operand)
                 };
                 results.push(Operand::SingleValue(result.into()));
             }

--- a/cmd/gravity/src/main.rs
+++ b/cmd/gravity/src/main.rs
@@ -421,6 +421,10 @@ impl Bindgen for Func {
         let iter_element = "e";
         let iter_base = "base";
 
+        let wazero_api_decode_i32 = &go::import("github.com/tetratelabs/wazero/api", "DecodeI32");
+        let wazero_api_encode_i32 = &go::import("github.com/tetratelabs/wazero/api", "EncodeI32");
+        let wazero_api_decode_u32 = &go::import("github.com/tetratelabs/wazero/api", "DecodeU32");
+
         // println!("instruction: {inst:?}, operands: {operands:?}");
 
         match inst {
@@ -1416,53 +1420,49 @@ impl Bindgen for Func {
                 let operand = &operands[0];
                 quote_in! { self.body =>
                     $['\r']
-                    $(&value) := int32($operand)
+                    $(&value) := $wazero_api_encode_i32(int32($operand))
                 }
                 results.push(Operand::SingleValue(value))
             }
             Instruction::CoreF32FromF32 => todo!("implement instruction: {inst:?}"),
             Instruction::CoreF64FromF64 => todo!("implement instruction: {inst:?}"),
-            // TODO: Validate the Go cast truncates the upper bits in the I32
             Instruction::S8FromI32 => {
                 let tmp = self.tmp();
                 let result = &format!("result{tmp}");
                 let operand = &operands[0];
                 quote_in! { self.body =>
                     $['\r']
-                    $result := int8($operand)
+                    $result := int8($wazero_api_decode_i32($operand))
                 };
                 results.push(Operand::SingleValue(result.into()));
             }
-            // TODO: Validate the Go cast truncates the upper bits in the I32
             Instruction::U8FromI32 => {
                 let tmp = self.tmp();
                 let result = &format!("result{tmp}");
                 let operand = &operands[0];
                 quote_in! { self.body =>
                     $['\r']
-                    $result := uint8($operand)
+                    $result := uint8($wazero_api_decode_u32($operand))
                 };
                 results.push(Operand::SingleValue(result.into()));
             }
-            // TODO: Validate the Go cast truncates the upper bits in the I32
             Instruction::S16FromI32 => {
                 let tmp = self.tmp();
                 let result = &format!("result{tmp}");
                 let operand = &operands[0];
                 quote_in! { self.body =>
                     $['\r']
-                    $result := int16($operand)
+                    $result := int16($wazero_api_decode_i32($operand))
                 };
                 results.push(Operand::SingleValue(result.into()));
             }
-            // TODO: Validate the Go cast truncates the upper bits in the I32
             Instruction::U16FromI32 => {
                 let tmp = self.tmp();
                 let result = &format!("result{tmp}");
                 let operand = &operands[0];
                 quote_in! { self.body =>
                     $['\r']
-                    $result := uint16($operand)
+                    $result := uint16($wazero_api_decode_u32($operand))
                 };
                 results.push(Operand::SingleValue(result.into()));
             }

--- a/cmd/gravity/src/main.rs
+++ b/cmd/gravity/src/main.rs
@@ -1406,19 +1406,11 @@ impl Bindgen for Func {
             Instruction::I64FromU64 => todo!("implement instruction: {inst:?}"),
             Instruction::I64FromS64 => todo!("implement instruction: {inst:?}"),
             Instruction::I32FromS32 => todo!("implement instruction: {inst:?}"),
-            Instruction::I32FromU16 => todo!("implement instruction: {inst:?}"),
-            Instruction::I32FromS16 => todo!("implement instruction: {inst:?}"),
-            Instruction::I32FromU8 => {
-                let tmp = self.tmp();
-                let value = format!("value{tmp}");
-                let operand = &operands[0];
-                quote_in! { self.body =>
-                    $['\r']
-                    $(&value) := int32($operand)
-                }
-                results.push(Operand::SingleValue(value))
-            }
-            Instruction::I32FromS8 => {
+            // All of these values should fit in Go's `int32` type which allows a safe cast
+            Instruction::I32FromU16
+            | Instruction::I32FromS16
+            | Instruction::I32FromU8
+            | Instruction::I32FromS8 => {
                 let tmp = self.tmp();
                 let value = format!("value{tmp}");
                 let operand = &operands[0];
@@ -1450,8 +1442,26 @@ impl Bindgen for Func {
                 };
                 results.push(Operand::SingleValue(result.into()));
             }
-            Instruction::S16FromI32 => todo!("implement instruction: {inst:?}"),
-            Instruction::U16FromI32 => todo!("implement instruction: {inst:?}"),
+            Instruction::S16FromI32 => {
+                let tmp = self.tmp();
+                let result = &format!("result{tmp}");
+                let operand = &operands[0];
+                quote_in! { self.body =>
+                    $['\r']
+                    $result := int16($operand)
+                };
+                results.push(Operand::SingleValue(result.into()));
+            }
+            Instruction::U16FromI32 => {
+                let tmp = self.tmp();
+                let result = &format!("result{tmp}");
+                let operand = &operands[0];
+                quote_in! { self.body =>
+                    $['\r']
+                    $result := uint16($operand)
+                };
+                results.push(Operand::SingleValue(result.into()));
+            }
             Instruction::S32FromI32 => todo!("implement instruction: {inst:?}"),
             Instruction::S64FromI64 => todo!("implement instruction: {inst:?}"),
             Instruction::U64FromI64 => todo!("implement instruction: {inst:?}"),

--- a/cmd/gravity2/Cargo.toml
+++ b/cmd/gravity2/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "gravity2"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+gravity-codegen = { path = "../../crates/gravity-codegen" }
+gravity-go = { path = "../../crates/gravity-go" }
+clap = { workspace = true }
+wit-bindgen-core = { workspace = true }
+wit-component = { workspace = true }
+genco = { workspace = true }
+anyhow = { workspace = true }
+heck = { workspace = true }
+hex = "0.4"

--- a/cmd/gravity2/src/main.rs
+++ b/cmd/gravity2/src/main.rs
@@ -1,0 +1,353 @@
+use std::{fs, process::ExitCode};
+
+use anyhow::{Context, Result};
+use clap::{Arg, ArgAction, Command};
+use genco::prelude::*;
+use gravity_codegen::GenerationContext;
+use gravity_go::{Go, GoResult, GoType};
+use heck::ToUpperCamelCase;
+use wit_bindgen_core::wit_parser::{Resolve, Type, TypeDefKind, WorldItem};
+
+// TODO: Move to gravity-cli crate
+const PRIMARY_WORLD_NAME: &str = "root";
+
+fn main() -> Result<ExitCode> {
+    let cmd = Command::new("gravity2")
+        .about("Generate Go bindings for WebAssembly components (refactored version)")
+        .arg(
+            Arg::new("world")
+                .short('w')
+                .long("world")
+                .help("Generate host bindings for the specified world")
+                .default_value(PRIMARY_WORLD_NAME),
+        )
+        .arg(
+            Arg::new("inline-wasm")
+                .long("inline-wasm")
+                .help("Include the WebAssembly file as hex bytes in the output code")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("file")
+                .help("The WebAssembly file to process")
+                .required(true),
+        )
+        .arg(
+            Arg::new("output")
+                .help("The file path where output generated code should be written")
+                .short('o')
+                .long("output"),
+        );
+
+    let matches = cmd.get_matches();
+    let selected_world = matches
+        .get_one::<String>("world")
+        .expect("world should have a default value");
+    let file = matches.get_one::<String>("file").expect("file is required");
+    let inline_wasm = matches.get_flag("inline-wasm");
+    let output = matches.get_one::<String>("output");
+
+    // Load the WebAssembly file
+    let wasm = fs::read(file).context(format!("Failed to read file: {file}"))?;
+
+    // Decode the component metadata
+    let (module, bindgen) = wit_component::metadata::decode(&wasm)
+        .map(|(module, bindgen)| (module.unwrap_or(wasm.clone()), bindgen))
+        .context("File should be a valid WebAssembly module")?;
+
+    // Get the world
+    let world_id = bindgen
+        .resolve
+        .worlds
+        .iter()
+        .find(|(_, w)| w.name == *selected_world)
+        .map(|(id, _)| id)
+        .ok_or_else(|| anyhow::anyhow!("World '{}' not found", selected_world))?;
+
+    let world = bindgen.resolve.worlds.get(world_id).unwrap();
+
+    // Create generation context
+    let mut context = GenerationContext::new();
+
+    let package_name = selected_world.replace('-', "_");
+
+    // TODO: Generate imports based on what's actually used
+    quote_in! { context.out =>
+        import (
+            $(quoted("context"))
+            $(quoted("embed"))
+            $(quoted("errors"))
+            $(quoted("github.com/tetratelabs/wazero"))
+            $(quoted("github.com/tetratelabs/wazero/api"))
+        )
+        $['\n']
+    };
+
+    // Generate embedded WASM if requested
+    if inline_wasm {
+        quote_in! { context.out =>
+            //go:embed $(hex::encode(&module))
+            var rawWasm []byte
+            $['\n']
+        };
+    } else {
+        quote_in! { context.out =>
+            //go:embed $(format!("{}.wasm", selected_world))
+            var rawWasm []byte
+            $['\n']
+        };
+    }
+
+    // Generate factory and instance types
+    let factory_name = format!("{}Factory", selected_world.to_upper_camel_case());
+    let instance_name = format!("{}Instance", selected_world.to_upper_camel_case());
+    let factory_name_str = factory_name.as_str();
+    let instance_name_str = instance_name.as_str();
+
+    quote_in! { context.out =>
+        type $factory_name_str struct {
+            runtime wazero.Runtime
+            module  wazero.CompiledModule
+        }
+        $['\n']
+        type $instance_name_str struct {
+            module api.Module
+        }
+        $['\n']
+    };
+
+    // Process imports (guest imports from host)
+    for (_name, import) in world.imports.iter() {
+        match import {
+            WorldItem::Interface { .. } => {
+                // TODO: Generate interface imports
+                quote_in! { context.out =>
+                    // TODO: Interface import
+                    $['\n']
+                };
+            }
+            WorldItem::Function(func) => {
+                // Generate import function
+                let _func_name = func.name.to_upper_camel_case();
+
+                // TODO: Process function parameters and results
+                quote_in! { context.out =>
+                    // Import function: $(func.name.as_str())
+                    // TODO: Generate import binding
+                    $['\n']
+                };
+            }
+            WorldItem::Type(type_id) => {
+                // TODO: Generate type definition
+                let type_name = bindgen
+                    .resolve
+                    .types
+                    .get(*type_id)
+                    .and_then(|t| t.name.as_deref())
+                    .unwrap_or("anonymous");
+                quote_in! { context.out =>
+                    // Type: $type_name
+                    // TODO: Generate type binding
+                    $['\n']
+                };
+            }
+        }
+    }
+
+    // Process exports (guest exports to host)
+    for (_name, export) in world.exports.iter() {
+        match export {
+            WorldItem::Interface { .. } => {
+                // TODO: Generate interface exports
+                quote_in! { context.out =>
+                    // TODO: Interface export
+                    $['\n']
+                };
+            }
+            WorldItem::Function(func) => {
+                // Generate export function
+                let func_name = func.name.to_upper_camel_case();
+
+                // Create a simplified function context
+                let result = func
+                    .result
+                    .as_ref()
+                    .map(|t| resolve_type(t, &bindgen.resolve))
+                    .map(GoResult::Anon)
+                    .unwrap_or(GoResult::Empty);
+
+                // TODO: Use the instruction handler system properly
+                let result_str = format_result(&result);
+                quote_in! { context.out =>
+                    func (i *$instance_name_str) $func_name(ctx context.Context) $result_str {
+                        // TODO: Generate proper function body using instruction handlers
+                        panic("not implemented")
+                    }
+                    $['\n']
+                };
+            }
+            WorldItem::Type(type_id) => {
+                // TODO: Generate type definition
+                let type_name = bindgen
+                    .resolve
+                    .types
+                    .get(*type_id)
+                    .and_then(|t| t.name.as_deref())
+                    .unwrap_or("anonymous");
+                quote_in! { context.out =>
+                    // Type: $type_name
+                    // TODO: Generate type binding
+                    $['\n']
+                };
+            }
+        }
+    }
+
+    // Generate factory constructor
+    quote_in! { context.out =>
+        func New$factory_name_str(ctx context.Context) (*$factory_name_str, error) {
+            runtime := wazero.NewRuntime(ctx)
+            module, err := runtime.CompileModule(ctx, rawWasm)
+            if err != nil {
+                return nil, err
+            }
+            return &$factory_name_str{
+                runtime: runtime,
+                module:  module,
+            }, nil
+        }
+        $['\n']
+        func (f *$factory_name_str) Instantiate(ctx context.Context) (*$instance_name_str, error) {
+            module, err := f.runtime.InstantiateModule(ctx, f.module, wazero.NewModuleConfig())
+            if err != nil {
+                return nil, err
+            }
+            return &$instance_name_str{module: module}, nil
+        }
+        $['\n']
+        func (f *$factory_name_str) Close(ctx context.Context) error {
+            return f.runtime.Close(ctx)
+        }
+        $['\n']
+        func (i *$instance_name_str) Close(ctx context.Context) error {
+            return i.module.Close(ctx)
+        }
+    };
+
+    // Format and write output
+    let mut writer = genco::fmt::FmtWriter::new(String::new());
+    let fmt = genco::fmt::Config::from_lang::<Go>().with_indentation(genco::fmt::Indentation::Tab);
+    let config = genco::lang::go::Config::default().with_package(package_name);
+
+    context
+        .out
+        .format_file(&mut writer.as_formatter(&fmt), &config)
+        .context("Failed to format Go code")?;
+
+    let generated_code = writer.into_inner();
+
+    match output {
+        Some(outpath) => {
+            // Write WASM file if not inlined
+            if !inline_wasm {
+                let wasm_outpath = std::path::Path::new(outpath)
+                    .with_file_name(format!("{}.wasm", selected_world));
+                fs::write(&wasm_outpath, &module).context(format!(
+                    "Failed to write WASM file: {}",
+                    wasm_outpath.display()
+                ))?;
+            }
+
+            // Write generated Go code
+            fs::write(outpath, generated_code)
+                .context(format!("Failed to write output file: {outpath}"))?;
+        }
+        None => {
+            println!("{}", generated_code);
+        }
+    }
+
+    Ok(ExitCode::SUCCESS)
+}
+
+// TODO: Move these helper functions to appropriate crates
+fn resolve_type(typ: &Type, resolve: &Resolve) -> GoType {
+    match typ {
+        Type::Bool => GoType::Bool,
+        Type::U8 => GoType::Uint8,
+        Type::U16 => GoType::Uint16,
+        Type::U32 => GoType::Uint32,
+        Type::U64 => GoType::Uint64,
+        Type::S8 => GoType::Int8,
+        Type::S16 => GoType::Int16,
+        Type::S32 => GoType::Int32,
+        Type::S64 => GoType::Int64,
+        Type::F32 => GoType::Float32,
+        Type::F64 => GoType::Float64,
+        Type::String => GoType::String,
+        Type::Char => GoType::Uint32, // Char is represented as uint32
+        Type::ErrorContext => GoType::Interface, // TODO: Handle ErrorContext properly
+        Type::Id(id) => {
+            let typedef = resolve.types.get(*id).unwrap();
+            match &typedef.kind {
+                TypeDefKind::List(inner) => GoType::Slice(Box::new(resolve_type(inner, resolve))),
+                TypeDefKind::Option(inner) => {
+                    GoType::ValueOrOk(Box::new(resolve_type(inner, resolve)))
+                }
+                TypeDefKind::Result(result) => {
+                    match (&result.ok, &result.err) {
+                        (Some(ok), None) => GoType::ValueOrOk(Box::new(resolve_type(ok, resolve))),
+                        (None, Some(err)) => {
+                            GoType::ValueOrError(Box::new(resolve_type(err, resolve)))
+                        }
+                        _ => GoType::Interface, // TODO: Handle other result cases
+                    }
+                }
+                TypeDefKind::Variant(_) => GoType::Interface,
+                TypeDefKind::Enum(_) => GoType::Uint32, // Enums are represented as integers
+                TypeDefKind::Record(_) | TypeDefKind::Flags(_) | TypeDefKind::Tuple(_) => {
+                    GoType::UserDefined(
+                        typedef
+                            .name
+                            .clone()
+                            .unwrap_or_else(|| "Anonymous".to_string()),
+                    )
+                }
+                TypeDefKind::Type(t) => resolve_type(t, resolve),
+                _ => GoType::Interface,
+            }
+        }
+    }
+}
+
+fn format_result(result: &GoResult) -> String {
+    match result {
+        GoResult::Empty => String::new(),
+        GoResult::Anon(typ) => format_type(typ),
+    }
+}
+
+fn format_type(typ: &GoType) -> String {
+    match typ {
+        GoType::Bool => "bool".to_string(),
+        GoType::Uint8 => "uint8".to_string(),
+        GoType::Uint16 => "uint16".to_string(),
+        GoType::Uint32 => "uint32".to_string(),
+        GoType::Uint64 => "uint64".to_string(),
+        GoType::Int8 => "int8".to_string(),
+        GoType::Int16 => "int16".to_string(),
+        GoType::Int32 => "int32".to_string(),
+        GoType::Int64 => "int64".to_string(),
+        GoType::Float32 => "float32".to_string(),
+        GoType::Float64 => "float64".to_string(),
+        GoType::String => "string".to_string(),
+        GoType::Error => "error".to_string(),
+        GoType::Interface => "interface{}".to_string(),
+        GoType::Pointer(inner) => format!("*{}", format_type(inner)),
+        GoType::ValueOrOk(inner) => format!("({}, bool)", format_type(inner)),
+        GoType::ValueOrError(inner) => format!("({}, error)", format_type(inner)),
+        GoType::Slice(inner) => format!("[]{}", format_type(inner)),
+        GoType::UserDefined(name) => name.to_upper_camel_case(),
+        GoType::Nothing => "".to_string(),
+    }
+}

--- a/crates/gravity-codegen/Cargo.toml
+++ b/crates/gravity-codegen/Cargo.toml
@@ -11,6 +11,7 @@ wit-bindgen-core = { workspace = true }
 wit-component = { workspace = true }
 anyhow = { workspace = true }
 heck = { workspace = true }
+indexmap = "2.0"
 
 [dev-dependencies]
 pretty_assertions = "1.4"

--- a/crates/gravity-codegen/Cargo.toml
+++ b/crates/gravity-codegen/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "gravity-codegen"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+gravity-go = { path = "../gravity-go" }
+gravity-wit = { path = "../gravity-wit" }
+genco = "0.17"
+wit-bindgen-core = "0.36"
+wit-parser = "0.220"
+wit-component = "0.220"
+anyhow = "1.0"
+heck = "0.5"
+
+[dev-dependencies]
+pretty_assertions = "1.4"

--- a/crates/gravity-codegen/Cargo.toml
+++ b/crates/gravity-codegen/Cargo.toml
@@ -6,12 +6,11 @@ edition = "2021"
 [dependencies]
 gravity-go = { path = "../gravity-go" }
 gravity-wit = { path = "../gravity-wit" }
-genco = "0.17"
-wit-bindgen-core = "0.36"
-wit-parser = "0.220"
-wit-component = "0.220"
-anyhow = "1.0"
-heck = "0.5"
+genco = { workspace = true }
+wit-bindgen-core = { workspace = true }
+wit-component = { workspace = true }
+anyhow = { workspace = true }
+heck = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = "1.4"

--- a/crates/gravity-codegen/src/bindings.rs
+++ b/crates/gravity-codegen/src/bindings.rs
@@ -1,11 +1,17 @@
 use anyhow::Result;
 use genco::prelude::*;
-use gravity_go::{quote, Go, Tokens};
+use gravity_go::{Go, Tokens};
 use wit_bindgen_core::wit_parser::{Function, TypeDef};
 
 pub struct BindingsGenerator {
     output: Tokens<Go>,
     types: Vec<TypeDef>,
+}
+
+impl Default for BindingsGenerator {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl BindingsGenerator {
@@ -26,7 +32,7 @@ impl BindingsGenerator {
         Ok(())
     }
 
-    pub fn add_function(&mut self, func: &Function) -> Result<()> {
+    pub fn add_function(&mut self, _func: &Function) -> Result<()> {
         // TODO: Generate function binding
         quote_in! { self.output =>
             $['\n']
@@ -35,7 +41,7 @@ impl BindingsGenerator {
         Ok(())
     }
 
-    pub fn add_import(&mut self, module: &str, items: Vec<String>) -> Result<()> {
+    pub fn add_import(&mut self, _module: &str, items: Vec<String>) -> Result<()> {
         quote_in! { self.output =>
             import (
                 $(for item in items join ($['\r']) => $(quoted(item)))

--- a/crates/gravity-codegen/src/bindings.rs
+++ b/crates/gravity-codegen/src/bindings.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use genco::prelude::*;
 use gravity_go::{quote, Go, Tokens};
-use wit_parser::{Function, TypeDef};
+use wit_bindgen_core::wit_parser::{Function, TypeDef};
 
 pub struct BindingsGenerator {
     output: Tokens<Go>,

--- a/crates/gravity-codegen/src/bindings.rs
+++ b/crates/gravity-codegen/src/bindings.rs
@@ -1,0 +1,51 @@
+use anyhow::Result;
+use genco::prelude::*;
+use gravity_go::{quote, Go, Tokens};
+use wit_parser::{Function, TypeDef};
+
+pub struct BindingsGenerator {
+    output: Tokens<Go>,
+    types: Vec<TypeDef>,
+}
+
+impl BindingsGenerator {
+    pub fn new() -> Self {
+        Self {
+            output: Tokens::new(),
+            types: Vec::new(),
+        }
+    }
+
+    pub fn add_type(&mut self, type_def: &TypeDef) -> Result<()> {
+        self.types.push(type_def.clone());
+        // TODO: Generate type definition
+        quote_in! { self.output =>
+            $['\n']
+            // Type: $(type_def.name.as_ref().unwrap_or(&String::from("anonymous")))
+        }
+        Ok(())
+    }
+
+    pub fn add_function(&mut self, func: &Function) -> Result<()> {
+        // TODO: Generate function binding
+        quote_in! { self.output =>
+            $['\n']
+            // Function: $(&func.name)
+        }
+        Ok(())
+    }
+
+    pub fn add_import(&mut self, module: &str, items: Vec<String>) -> Result<()> {
+        quote_in! { self.output =>
+            import (
+                $(for item in items join ($['\r']) => $(quoted(item)))
+            )
+            $['\n']
+        }
+        Ok(())
+    }
+
+    pub fn generate(self) -> String {
+        self.output.to_string().expect("Failed to generate Go code")
+    }
+}

--- a/crates/gravity-codegen/src/bindings.rs
+++ b/crates/gravity-codegen/src/bindings.rs
@@ -3,8 +3,14 @@ use genco::prelude::*;
 use gravity_go::{Go, Tokens};
 use wit_bindgen_core::wit_parser::{Function, TypeDef};
 
+/// Generator for WebAssembly Interface Types (WIT) bindings in Go.
+///
+/// This struct accumulates type definitions, function bindings, and imports,
+/// then generates the corresponding Go code.
 pub struct BindingsGenerator {
+    /// Accumulated output tokens for the generated Go code.
     output: Tokens<Go>,
+    /// Collection of type definitions to be generated.
     types: Vec<TypeDef>,
 }
 
@@ -15,6 +21,9 @@ impl Default for BindingsGenerator {
 }
 
 impl BindingsGenerator {
+    /// Creates a new empty bindings generator.
+    ///
+    /// Initializes the generator with empty output and no types.
     pub fn new() -> Self {
         Self {
             output: Tokens::new(),
@@ -22,25 +31,52 @@ impl BindingsGenerator {
         }
     }
 
+    /// Adds a type definition to be generated.
+    ///
+    /// Stores the type definition and generates a placeholder comment in the output.
+    /// The actual type generation is marked as TODO.
+    ///
+    /// # Arguments
+    /// * `type_def` - The WIT type definition to add.
+    ///
+    /// # Returns
+    /// Ok(()) on success.
     pub fn add_type(&mut self, type_def: &TypeDef) -> Result<()> {
         self.types.push(type_def.clone());
         // TODO: Generate type definition
-        quote_in! { self.output =>
-            $['\n']
-            // Type: $(type_def.name.as_ref().unwrap_or(&String::from("anonymous")))
-        }
+        let type_name = type_def.name.as_deref().unwrap_or("anonymous");
+        self.output.line();
+        self.output.append(format!("// Type: {}", type_name));
         Ok(())
     }
 
-    pub fn add_function(&mut self, _func: &Function) -> Result<()> {
+    /// Adds a function binding to be generated.
+    ///
+    /// Generates a placeholder comment for the function in the output.
+    /// The actual function binding generation is marked as TODO.
+    ///
+    /// # Arguments
+    /// * `func` - The WIT function to add bindings for.
+    ///
+    /// # Returns
+    /// Ok(()) on success.
+    pub fn add_function(&mut self, func: &Function) -> Result<()> {
         // TODO: Generate function binding
-        quote_in! { self.output =>
-            $['\n']
-            // Function: $(&func.name)
-        }
+        self.output.line();
+        self.output.append(format!("// Function: {}", func.name));
         Ok(())
     }
 
+    /// Adds an import statement with the specified items.
+    ///
+    /// Generates a Go import block with the provided items.
+    ///
+    /// # Arguments
+    /// * `_module` - The module name (currently unused).
+    /// * `items` - List of items to import.
+    ///
+    /// # Returns
+    /// Ok(()) on success.
     pub fn add_import(&mut self, _module: &str, items: Vec<String>) -> Result<()> {
         quote_in! { self.output =>
             import (
@@ -51,7 +87,151 @@ impl BindingsGenerator {
         Ok(())
     }
 
+    /// Generates the final Go code from all accumulated definitions.
+    ///
+    /// Consumes the generator and returns the generated Go code as a string.
+    ///
+    /// # Returns
+    /// The generated Go code.
+    ///
+    /// # Panics
+    /// Panics if code generation fails.
     pub fn generate(self) -> String {
         self.output.to_string().expect("Failed to generate Go code")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wit_bindgen_core::wit_parser::{TypeDefKind, TypeOwner};
+
+    fn create_test_typedef(name: &str) -> TypeDef {
+        TypeDef {
+            name: Some(name.to_string()),
+            kind: TypeDefKind::Type(wit_bindgen_core::wit_parser::Type::Bool),
+            owner: TypeOwner::None,
+            docs: Default::default(),
+            stability: Default::default(),
+        }
+    }
+
+    #[test]
+    fn test_new_generator() {
+        let generator = BindingsGenerator::new();
+        assert_eq!(generator.types.len(), 0);
+        let output = generator.generate();
+        assert_eq!(output, "");
+    }
+
+    #[test]
+    fn test_add_type() {
+        let mut generator = BindingsGenerator::new();
+        let type_def = create_test_typedef("MyType");
+
+        generator.add_type(&type_def).unwrap();
+        assert_eq!(generator.types.len(), 1);
+
+        let output = generator.generate();
+        assert!(output.contains("// Type: MyType"));
+    }
+
+    #[test]
+    fn test_add_multiple_types() {
+        let mut generator = BindingsGenerator::new();
+
+        generator.add_type(&create_test_typedef("Type1")).unwrap();
+        generator.add_type(&create_test_typedef("Type2")).unwrap();
+        generator.add_type(&create_test_typedef("Type3")).unwrap();
+
+        assert_eq!(generator.types.len(), 3);
+
+        let output = generator.generate();
+        assert!(output.contains("// Type: Type1"));
+        assert!(output.contains("// Type: Type2"));
+        assert!(output.contains("// Type: Type3"));
+    }
+
+    #[test]
+    fn test_add_import() {
+        let mut generator = BindingsGenerator::new();
+
+        generator
+            .add_import("fmt", vec!["Println".to_string(), "Sprintf".to_string()])
+            .unwrap();
+
+        let output = generator.generate();
+        assert!(output.contains("import ("));
+        assert!(output.contains("\"Println\""));
+        assert!(output.contains("\"Sprintf\""));
+    }
+
+    #[test]
+    fn test_add_function() {
+        let mut generator = BindingsGenerator::new();
+
+        // Create a test function
+        let func = wit_bindgen_core::wit_parser::Function {
+            name: "testFunc".to_string(),
+            kind: wit_bindgen_core::wit_parser::FunctionKind::Freestanding,
+            params: Default::default(),
+            result: Default::default(),
+            docs: Default::default(),
+            stability: Default::default(),
+        };
+
+        generator.add_function(&func).unwrap();
+
+        let output = generator.generate();
+        assert!(output.contains("// Function: testFunc"));
+    }
+
+    #[test]
+    fn test_complete_generation() {
+        let mut generator = BindingsGenerator::new();
+
+        // Add various elements
+        generator
+            .add_import("fmt", vec!["Println".to_string()])
+            .unwrap();
+        generator.add_type(&create_test_typedef("User")).unwrap();
+        generator.add_type(&create_test_typedef("Product")).unwrap();
+
+        let func = wit_bindgen_core::wit_parser::Function {
+            name: "processUser".to_string(),
+            kind: wit_bindgen_core::wit_parser::FunctionKind::Freestanding,
+            params: Default::default(),
+            result: Default::default(),
+            docs: Default::default(),
+            stability: Default::default(),
+        };
+        generator.add_function(&func).unwrap();
+
+        let output = generator.generate();
+
+        // Verify all components are in the output
+        assert!(output.contains("import"));
+        assert!(output.contains("Println"));
+        assert!(output.contains("// Type: User"));
+        assert!(output.contains("// Type: Product"));
+        assert!(output.contains("// Function: processUser"));
+    }
+
+    #[test]
+    fn test_anonymous_type() {
+        let mut generator = BindingsGenerator::new();
+
+        let type_def = TypeDef {
+            name: None, // Anonymous type
+            kind: TypeDefKind::Type(wit_bindgen_core::wit_parser::Type::String),
+            owner: TypeOwner::None,
+            docs: Default::default(),
+            stability: Default::default(),
+        };
+
+        generator.add_type(&type_def).unwrap();
+
+        let output = generator.generate();
+        assert!(output.contains("// Type: anonymous"));
     }
 }

--- a/crates/gravity-codegen/src/context.rs
+++ b/crates/gravity-codegen/src/context.rs
@@ -1,5 +1,4 @@
-use anyhow::Result;
-use gravity_go::{quote, Go, GoType, Operand, Tokens};
+use gravity_go::{Go, GoType, Operand, Tokens};
 use std::collections::HashMap;
 
 pub struct GenerationContext {
@@ -8,6 +7,12 @@ pub struct GenerationContext {
     pub operands: Vec<Operand>,
     pub vars: HashMap<String, GoType>,
     tmp_counter: usize,
+}
+
+impl Default for GenerationContext {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl GenerationContext {

--- a/crates/gravity-codegen/src/context.rs
+++ b/crates/gravity-codegen/src/context.rs
@@ -1,11 +1,20 @@
 use gravity_go::{Go, GoType, Operand, Tokens};
 use std::collections::HashMap;
 
+/// Context for code generation that tracks state during instruction processing.
+///
+/// This struct maintains the operand stack, variable mappings, temporary counter,
+/// and output tokens during the code generation process.
 pub struct GenerationContext {
+    /// Output tokens for declarations and top-level code.
     pub out: Tokens<Go>,
+    /// Body tokens for function implementations.
     pub body: Tokens<Go>,
+    /// Stack of operands being processed.
     pub operands: Vec<Operand>,
+    /// Mapping from variable names to their Go types.
     pub vars: HashMap<String, GoType>,
+    /// Counter for generating unique temporary variable names.
     tmp_counter: usize,
 }
 
@@ -16,6 +25,9 @@ impl Default for GenerationContext {
 }
 
 impl GenerationContext {
+    /// Creates a new empty generation context.
+    ///
+    /// Initializes all fields to their default empty states.
     pub fn new() -> Self {
         Self {
             out: Tokens::new(),
@@ -26,23 +38,142 @@ impl GenerationContext {
         }
     }
 
+    /// Generates a unique temporary variable identifier.
+    ///
+    /// Returns the current counter value and increments it for the next call.
+    /// This ensures each temporary variable has a unique numeric identifier.
+    ///
+    /// # Returns
+    /// A unique numeric identifier for a temporary variable.
     pub fn tmp(&mut self) -> usize {
         let current = self.tmp_counter;
         self.tmp_counter += 1;
         current
     }
 
+    /// Pushes an operand onto the operand stack.
+    ///
+    /// # Arguments
+    /// * `operand` - The operand to push onto the stack.
     pub fn push_operand(&mut self, operand: Operand) {
         self.operands.push(operand);
     }
 
+    /// Pops multiple operands from the stack.
+    ///
+    /// Removes the specified number of operands from the top of the stack
+    /// and returns them in the order they were popped (bottom to top of the removed segment).
+    ///
+    /// # Arguments
+    /// * `count` - The number of operands to pop.
+    ///
+    /// # Returns
+    /// A vector containing the popped operands.
+    ///
+    /// # Panics
+    /// Panics if there are fewer operands on the stack than requested.
     pub fn pop_operands(&mut self, count: usize) -> Vec<Operand> {
         let start = self.operands.len() - count;
         self.operands.drain(start..).collect()
     }
 
+    /// Peeks at multiple operands from the top of the stack without removing them.
+    ///
+    /// # Arguments
+    /// * `count` - The number of operands to peek at.
+    ///
+    /// # Returns
+    /// A slice containing the top `count` operands.
+    ///
+    /// # Panics
+    /// Panics if there are fewer operands on the stack than requested.
     pub fn peek_operands(&self, count: usize) -> &[Operand] {
         let start = self.operands.len() - count;
         &self.operands[start..]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tmp_counter() {
+        let mut ctx = GenerationContext::new();
+        assert_eq!(ctx.tmp(), 0);
+        assert_eq!(ctx.tmp(), 1);
+        assert_eq!(ctx.tmp(), 2);
+        assert_eq!(ctx.tmp(), 3);
+    }
+
+    #[test]
+    fn test_operand_stack() {
+        let mut ctx = GenerationContext::new();
+
+        // Push some operands
+        ctx.push_operand(Operand::Literal("0".to_string()));
+        ctx.push_operand(Operand::SingleValue("var1".to_string()));
+        ctx.push_operand(Operand::MultiValue(("a".to_string(), "b".to_string())));
+
+        // Check stack size
+        assert_eq!(ctx.operands.len(), 3);
+
+        // Peek at top 2
+        let peeked = ctx.peek_operands(2);
+        assert_eq!(peeked.len(), 2);
+        assert_eq!(peeked[0], Operand::SingleValue("var1".to_string()));
+        assert_eq!(
+            peeked[1],
+            Operand::MultiValue(("a".to_string(), "b".to_string()))
+        );
+
+        // Pop 2 operands
+        let popped = ctx.pop_operands(2);
+        assert_eq!(popped.len(), 2);
+        assert_eq!(popped[0], Operand::SingleValue("var1".to_string()));
+        assert_eq!(
+            popped[1],
+            Operand::MultiValue(("a".to_string(), "b".to_string()))
+        );
+
+        // Check remaining stack
+        assert_eq!(ctx.operands.len(), 1);
+        assert_eq!(ctx.operands[0], Operand::Literal("0".to_string()));
+    }
+
+    #[test]
+    fn test_variable_storage() {
+        let mut ctx = GenerationContext::new();
+
+        // Store some variables with types
+        ctx.vars.insert("x".to_string(), GoType::Uint32);
+        ctx.vars.insert("name".to_string(), GoType::String);
+        ctx.vars
+            .insert("data".to_string(), GoType::Slice(Box::new(GoType::Uint8)));
+
+        assert_eq!(ctx.vars.get("x"), Some(&GoType::Uint32));
+        assert_eq!(ctx.vars.get("name"), Some(&GoType::String));
+        assert_eq!(
+            ctx.vars.get("data"),
+            Some(&GoType::Slice(Box::new(GoType::Uint8)))
+        );
+        assert_eq!(ctx.vars.get("unknown"), None);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_peek_too_many() {
+        let ctx = GenerationContext::new();
+        // This should panic because we're trying to peek more than available
+        let _ = ctx.peek_operands(1);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_pop_too_many() {
+        let mut ctx = GenerationContext::new();
+        ctx.push_operand(Operand::Literal("0".to_string()));
+        // This should panic because we're trying to pop more than available
+        let _ = ctx.pop_operands(2);
     }
 }

--- a/crates/gravity-codegen/src/context.rs
+++ b/crates/gravity-codegen/src/context.rs
@@ -1,0 +1,43 @@
+use anyhow::Result;
+use gravity_go::{quote, Go, GoType, Operand, Tokens};
+use std::collections::HashMap;
+
+pub struct GenerationContext {
+    pub out: Tokens<Go>,
+    pub body: Tokens<Go>,
+    pub operands: Vec<Operand>,
+    pub vars: HashMap<String, GoType>,
+    tmp_counter: usize,
+}
+
+impl GenerationContext {
+    pub fn new() -> Self {
+        Self {
+            out: Tokens::new(),
+            body: Tokens::new(),
+            operands: Vec::new(),
+            vars: HashMap::new(),
+            tmp_counter: 0,
+        }
+    }
+
+    pub fn tmp(&mut self) -> usize {
+        let current = self.tmp_counter;
+        self.tmp_counter += 1;
+        current
+    }
+
+    pub fn push_operand(&mut self, operand: Operand) {
+        self.operands.push(operand);
+    }
+
+    pub fn pop_operands(&mut self, count: usize) -> Vec<Operand> {
+        let start = self.operands.len() - count;
+        self.operands.drain(start..).collect()
+    }
+
+    pub fn peek_operands(&self, count: usize) -> &[Operand] {
+        let start = self.operands.len() - count;
+        &self.operands[start..]
+    }
+}

--- a/crates/gravity-codegen/src/exports.rs
+++ b/crates/gravity-codegen/src/exports.rs
@@ -1,0 +1,1481 @@
+use anyhow::Result;
+use genco::prelude::*;
+use gravity_go::{Go, GoIdentifier, GoResult, GoType, Operand};
+use heck::{ToLowerCamelCase, ToUpperCamelCase};
+use wit_bindgen_core::{
+    abi::{AbiVariant, Bindgen, Instruction, LiftLower},
+    wit_parser::{Function, Resolve, SizeAlign, WorldItem, WorldKey},
+};
+
+use crate::context::GenerationContext;
+use crate::imports::GoImports;
+use crate::resolve_type;
+
+/// Configuration for export generation
+pub struct ExportConfig<'a> {
+    pub world_name: &'a str,
+    pub instance_name: &'a GoIdentifier<'a>,
+    pub go_imports: &'a GoImports,
+}
+
+/// Generator for exported functions
+pub struct ExportGenerator<'a> {
+    context: &'a mut GenerationContext,
+    config: ExportConfig<'a>,
+    resolve: &'a Resolve,
+}
+
+impl<'a> ExportGenerator<'a> {
+    pub fn new(
+        context: &'a mut GenerationContext,
+        config: ExportConfig<'a>,
+        resolve: &'a Resolve,
+    ) -> Self {
+        Self {
+            context,
+            config,
+            resolve,
+        }
+    }
+
+    /// Generate all exports for a world
+    pub fn generate(
+        mut self,
+        world_exports: &indexmap::IndexMap<WorldKey, WorldItem>,
+    ) -> Result<()> {
+        eprintln!(
+            "DEBUG ExportGenerator::generate called with {} exports",
+            world_exports.len()
+        );
+        for (key, world_item) in world_exports.iter() {
+            eprintln!("DEBUG Processing export key: {:?}", key);
+            match world_item {
+                WorldItem::Function(func) => {
+                    eprintln!("DEBUG Generating function export: {}", func.name);
+                    self.generate_function_export(func)?;
+                }
+                WorldItem::Interface { .. } => {
+                    eprintln!("DEBUG Skipping interface export");
+                    // TODO: Handle interface exports when needed
+                }
+                WorldItem::Type(_) => {
+                    eprintln!("DEBUG Skipping type export");
+                    // Type exports are handled separately
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Generate a single exported function as a method on the instance
+    fn generate_function_export(&mut self, func: &Function) -> Result<()> {
+        eprintln!("DEBUG generate_function_export: {}", func.name);
+        eprintln!("  func.result: {:?}", func.result);
+
+        // Build parameters
+        let mut params: Vec<(GoIdentifier<'_>, GoType)> = Vec::with_capacity(func.params.len());
+        for (name, wit_type) in func.params.iter() {
+            let go_type = resolve_type(wit_type, self.resolve)?;
+            match go_type {
+                // We can't represent this as an argument type so we unwrap the Some type
+                // TODO: Figure out a better way to handle this
+                GoType::ValueOrOk(typ) => params.push((GoIdentifier::Local { name }, *typ)),
+                typ => params.push((GoIdentifier::Local { name }, typ)),
+            }
+        }
+
+        // Determine result type
+        let result = match &func.result {
+            Some(wit_type) => {
+                eprintln!("  About to resolve wit_type: {:?}", wit_type);
+                let go_type = resolve_type(wit_type, self.resolve)?;
+                eprintln!(
+                    "  Resolved: Function {} has result type: {:?} -> GoType: {:?}",
+                    func.name, wit_type, go_type
+                );
+                GoResult::Anon(go_type)
+            }
+            None => GoResult::Empty,
+        };
+
+        // Generate the function body using wit_bindgen_core::abi
+        let mut sizes = SizeAlign::default();
+        sizes.fill(self.resolve);
+
+        let mut func_impl = FuncImpl::new(result, sizes, self.config.go_imports);
+
+        wit_bindgen_core::abi::call(
+            self.resolve,
+            AbiVariant::GuestExport,
+            LiftLower::LowerArgsLiftResults,
+            func,
+            &mut func_impl,
+            false, // async is not currently supported
+        );
+
+        // Generate the method
+        let fn_name = GoIdentifier::Public {
+            name: &func.name.to_upper_camel_case(),
+        };
+        let instance = self.config.instance_name;
+        let go_imports = self.config.go_imports;
+
+        // Create arg assignments from parameters to func args
+        let arg_assignments = func_impl
+            .args
+            .iter()
+            .zip(params.iter())
+            .map(|(arg, (param, _))| (arg, param))
+            .collect::<Vec<_>>();
+
+        // Debug output temporarily removed during refactor
+
+        quote_in! { self.context.out =>
+            $['\n']
+            func (i *$instance) $fn_name(
+                $['\r']
+                ctx $(&go_imports.context),
+                $(for (name, typ) in params.iter() join ($['\r']) => $name $typ,)
+            ) $(&func_impl.result) {
+                $(for (arg, param) in arg_assignments join ($['\r']) => $arg := $param)
+                $(&func_impl.body)
+            }
+        };
+
+        Ok(())
+    }
+}
+
+/// Implementation of function body generation
+struct FuncImpl<'a> {
+    result: GoResult,
+    sizes: SizeAlign,
+    go_imports: &'a GoImports,
+    args: Vec<String>,
+    tmp_counter: usize,
+    body: Tokens<Go>,
+    block_storage: Vec<Tokens<Go>>,
+    blocks: Vec<(Tokens<Go>, Vec<Operand>)>,
+}
+
+impl<'a> FuncImpl<'a> {
+    fn new(result: GoResult, sizes: SizeAlign, go_imports: &'a GoImports) -> Self {
+        Self {
+            result,
+            sizes,
+            go_imports,
+            args: Vec::new(),
+            tmp_counter: 0,
+            body: Tokens::new(),
+            block_storage: Vec::new(),
+            blocks: Vec::new(),
+        }
+    }
+
+    fn tmp(&mut self) -> usize {
+        let counter = self.tmp_counter;
+        self.tmp_counter += 1;
+        counter
+    }
+
+    fn push_arg(&mut self, arg: &str) {
+        self.args.push(arg.to_string());
+    }
+
+    fn pop_block(&mut self) -> (Tokens<Go>, Vec<Operand>) {
+        self.blocks.pop().expect("should have block to pop")
+    }
+}
+
+impl<'a> Bindgen for FuncImpl<'a> {
+    type Operand = Operand;
+
+    fn return_pointer(
+        &mut self,
+        _size: wit_bindgen_core::wit_parser::ArchitectureSize,
+        _align: wit_bindgen_core::wit_parser::Alignment,
+    ) -> Self::Operand {
+        let tmp = self.tmp();
+        let ret = &format!("ret{tmp}");
+        quote_in! { self.body =>
+            $['\r']
+            $ret := return_pointer()
+        };
+        Operand::SingleValue(ret.into())
+    }
+
+    fn is_list_canonical(
+        &self,
+        _resolve: &Resolve,
+        _element: &wit_bindgen_core::wit_parser::Type,
+    ) -> bool {
+        false
+    }
+
+    fn emit(
+        &mut self,
+        resolve: &Resolve,
+        inst: &Instruction<'_>,
+        operands: &mut Vec<Self::Operand>,
+        results: &mut Vec<Self::Operand>,
+    ) {
+        // Debug output for all instructions
+        eprintln!("DEBUG emit called: {:?}", std::mem::discriminant(inst));
+        eprintln!("  instruction = {:?}", inst);
+        eprintln!("  operands = {:?}", operands);
+        eprintln!("  results before = {:?}", results);
+
+        // Debug output for ResultLift
+        if matches!(inst, Instruction::ResultLift { .. }) {
+            eprintln!("DEBUG: Processing ResultLift instruction");
+            eprintln!("  operands.len() = {}", operands.len());
+            eprintln!("  results.len() before = {}", results.len());
+        }
+
+        match inst {
+            Instruction::GetArg { nth } => {
+                let arg = &format!("arg{nth}");
+                self.push_arg(arg);
+                results.push(Operand::SingleValue(arg.into()));
+            }
+            Instruction::ConstZero { tys } => {
+                for _ in tys.iter() {
+                    results.push(Operand::Literal("0".into()));
+                }
+            }
+            Instruction::I32FromBool => {
+                let tmp = self.tmp();
+                let value = &format!("value{tmp}");
+                let operand = &operands[0];
+                quote_in! { self.body =>
+                    $['\r']
+                    var $value
+                    if $operand { $value = 1 } else { $value = 0 }
+                };
+                results.push(Operand::SingleValue(value.into()));
+            }
+            Instruction::BoolFromI32 => {
+                let tmp = self.tmp();
+                let value = &format!("value{tmp}");
+                let operand = &operands[0];
+                quote_in! { self.body =>
+                    $['\r']
+                    $value := $operand != 0
+                };
+                results.push(Operand::SingleValue(value.into()));
+            }
+            Instruction::I32FromU8 => {
+                let tmp = self.tmp();
+                let value = &format!("value{tmp}");
+                let operand = &operands[0];
+                quote_in! { self.body =>
+                    $['\r']
+                    $value := uint32($operand)
+                };
+                results.push(Operand::SingleValue(value.into()));
+            }
+            Instruction::I32FromS8 => {
+                let tmp = self.tmp();
+                let value = &format!("value{tmp}");
+                let operand = &operands[0];
+                quote_in! { self.body =>
+                    $['\r']
+                    $value := uint32($operand)
+                };
+                results.push(Operand::SingleValue(value.into()));
+            }
+            Instruction::I32FromU16 => {
+                let tmp = self.tmp();
+                let value = &format!("value{tmp}");
+                let operand = &operands[0];
+                quote_in! { self.body =>
+                    $['\r']
+                    $value := uint32($operand)
+                };
+                results.push(Operand::SingleValue(value.into()));
+            }
+            Instruction::I32FromS16 => {
+                let tmp = self.tmp();
+                let value = &format!("value{tmp}");
+                let operand = &operands[0];
+                quote_in! { self.body =>
+                    $['\r']
+                    $value := uint32($operand)
+                };
+                results.push(Operand::SingleValue(value.into()));
+            }
+            Instruction::I32FromU32 => {
+                let tmp = self.tmp();
+                let value = &format!("value{tmp}");
+                let operand = &operands[0];
+                quote_in! { self.body =>
+                    $['\r']
+                    $value := api.EncodeU32($operand)
+                };
+                results.push(Operand::SingleValue(value.into()));
+            }
+            Instruction::I32FromS32 => {
+                let tmp = self.tmp();
+                let value = &format!("value{tmp}");
+                let operand = &operands[0];
+                quote_in! { self.body =>
+                    $['\r']
+                    $value := api.EncodeI32($operand)
+                };
+                results.push(Operand::SingleValue(value.into()));
+            }
+            Instruction::U32FromI32 => {
+                let tmp = self.tmp();
+                let value = &format!("value{tmp}");
+                let operand = &operands[0];
+                quote_in! { self.body =>
+                    $['\r']
+                    $value := api.DecodeU32(uint64($operand))
+                };
+                results.push(Operand::SingleValue(value.into()));
+            }
+            Instruction::S32FromI32 => {
+                let tmp = self.tmp();
+                let value = &format!("value{tmp}");
+                let operand = &operands[0];
+                quote_in! { self.body =>
+                    $['\r']
+                    $value := api.DecodeI32($operand)
+                };
+                results.push(Operand::SingleValue(value.into()));
+            }
+            Instruction::U8FromI32 => {
+                let tmp = self.tmp();
+                let value = &format!("value{tmp}");
+                let operand = &operands[0];
+                quote_in! { self.body =>
+                    $['\r']
+                    $value := uint8(api.DecodeU32($operand))
+                };
+                results.push(Operand::SingleValue(value.into()));
+            }
+            Instruction::S8FromI32 => {
+                let tmp = self.tmp();
+                let value = &format!("value{tmp}");
+                let operand = &operands[0];
+                quote_in! { self.body =>
+                    $['\r']
+                    $value := int8(api.DecodeI32($operand))
+                };
+                results.push(Operand::SingleValue(value.into()));
+            }
+            Instruction::U16FromI32 => {
+                let tmp = self.tmp();
+                let value = &format!("value{tmp}");
+                let operand = &operands[0];
+                quote_in! { self.body =>
+                    $['\r']
+                    $value := uint16(api.DecodeU32($operand))
+                };
+                results.push(Operand::SingleValue(value.into()));
+            }
+            Instruction::S16FromI32 => {
+                let tmp = self.tmp();
+                let value = &format!("value{tmp}");
+                let operand = &operands[0];
+                quote_in! { self.body =>
+                    $['\r']
+                    $value := int16(api.DecodeI32($operand))
+                };
+                results.push(Operand::SingleValue(value.into()));
+            }
+            Instruction::F32FromCoreF32 => {
+                let tmp = self.tmp();
+                let value = &format!("value{tmp}");
+                let operand = &operands[0];
+                quote_in! { self.body =>
+                    $['\r']
+                    $value := api.DecodeF32($operand)
+                };
+                results.push(Operand::SingleValue(value.into()));
+            }
+            Instruction::F64FromCoreF64 => {
+                let tmp = self.tmp();
+                let value = &format!("value{tmp}");
+                let operand = &operands[0];
+                quote_in! { self.body =>
+                    $['\r']
+                    $value := api.DecodeF64($operand)
+                };
+                results.push(Operand::SingleValue(value.into()));
+            }
+            Instruction::CoreF32FromF32 => {
+                let tmp = self.tmp();
+                let value = &format!("value{tmp}");
+                let operand = &operands[0];
+                quote_in! { self.body =>
+                    $['\r']
+                    $value := api.EncodeF32($operand)
+                };
+                results.push(Operand::SingleValue(value.into()));
+            }
+            Instruction::CoreF64FromF64 => {
+                let tmp = self.tmp();
+                let value = &format!("value{tmp}");
+                let operand = &operands[0];
+                quote_in! { self.body =>
+                    $['\r']
+                    $value := api.EncodeF64(float64($operand))
+                };
+                results.push(Operand::SingleValue(value.into()));
+            }
+            Instruction::I64FromS64 => {
+                let tmp = self.tmp();
+                let value = &format!("value{tmp}");
+                let operand = &operands[0];
+                quote_in! { self.body =>
+                    $['\r']
+                    $value := api.EncodeI64($operand)
+                };
+                results.push(Operand::SingleValue(value.into()));
+            }
+            Instruction::I64FromU64 => {
+                let tmp = self.tmp();
+                let value = &format!("value{tmp}");
+                let operand = &operands[0];
+                quote_in! { self.body =>
+                    $['\r']
+                    $value := api.EncodeU32(uint32($operand))
+                };
+                results.push(Operand::SingleValue(value.into()));
+            }
+            Instruction::S64FromI64 => {
+                let tmp = self.tmp();
+                let value = &format!("value{tmp}");
+                let operand = &operands[0];
+                quote_in! { self.body =>
+                    $['\r']
+                    $value := uint64($operand)
+                };
+                results.push(Operand::SingleValue(value.into()));
+            }
+            Instruction::U64FromI64 => {
+                let tmp = self.tmp();
+                let value = &format!("value{tmp}");
+                let operand = &operands[0];
+                quote_in! { self.body =>
+                    $['\r']
+                    $value := uint64($operand)
+                };
+                results.push(Operand::SingleValue(value.into()));
+            }
+            Instruction::CharFromI32 => {
+                let tmp = self.tmp();
+                let value = &format!("value{tmp}");
+                let operand = &operands[0];
+                quote_in! { self.body =>
+                    $['\r']
+                    $value := rune($operand)
+                };
+                results.push(Operand::SingleValue(value.into()));
+            }
+            Instruction::I32FromChar => {
+                let tmp = self.tmp();
+                let value = &format!("value{tmp}");
+                let operand = &operands[0];
+                quote_in! { self.body =>
+                    $['\r']
+                    $value := uint32($operand)
+                };
+                results.push(Operand::SingleValue(value.into()));
+            }
+            Instruction::StringLift { .. } => {
+                eprintln!("DEBUG: StringLift raw operands = {:?}", operands);
+                eprintln!("DEBUG: operands.len() = {}", operands.len());
+                if operands.len() >= 2 {
+                    eprintln!("DEBUG: operands[0] = {:?}", operands[0]);
+                    eprintln!("DEBUG: operands[1] = {:?}", operands[1]);
+                }
+                let ptr = &operands[0];
+                let len = &operands[1];
+                let tmp = self.tmp();
+                let buf = &format!("buf{tmp}");
+                let ok = &format!("ok{tmp}");
+                let value = &format!("value{tmp}");
+                eprintln!("DEBUG: StringLift assigned ptr={:?}, len={:?}", ptr, len);
+                quote_in! { self.body =>
+                    $['\r']
+                    $(&self.go_imports.fmt)("DEBUG: StringLift ptr=%d, len=%d\n", $ptr, $len)
+                    $buf, $ok := i.module.Memory().Read(uint32($ptr), uint32($len))
+                    $(&self.go_imports.fmt)("DEBUG: Read result -> buf_len=%d, ok=%v\n", len($buf), $ok)
+                    if !$ok {
+                        panic($(&self.go_imports.errors)("failed to read bytes from memory"))
+                    }
+                    $value := string($buf)
+                    $(&self.go_imports.fmt)("DEBUG: Final string value: \"%s\"\n", $value)
+                };
+                results.push(Operand::SingleValue(value.into()));
+            }
+            Instruction::StringLower { .. } => {
+                let str = &operands[0];
+                let tmp = self.tmp();
+                let ptr = &format!("ptr{tmp}");
+                let len = &format!("len{tmp}");
+                let err = &format!("err{tmp}");
+                quote_in! { self.body =>
+                    $['\r']
+                    memory := i.module.Memory()
+                    realloc := i.module.ExportedFunction("cabi_realloc")
+                    $ptr, $len, $err := writeString(ctx, $str, memory, realloc)
+                    if $err != nil {
+                        panic($err)
+                    }
+                };
+                results.push(Operand::SingleValue(ptr.into()));
+                results.push(Operand::SingleValue(len.into()));
+            }
+            Instruction::ListLift { element, .. } => {
+                let (body, body_results) = self.blocks.pop().unwrap();
+                let tmp = self.tmp();
+                let size = self.sizes.size(element).size_wasm32();
+                let len = &format!("len{tmp}");
+                let base = &format!("base{tmp}");
+                let result = &format!("result{tmp}");
+                let idx = &format!("idx{tmp}");
+
+                let base_operand = &operands[0];
+                let len_operand = &operands[1];
+                let body_result = &body_results[0];
+
+                // Generate proper Go type for the element using resolve_type
+                let go_type = crate::resolve_type(element, resolve).unwrap();
+
+                // For quote interpolation, we need to format the GoType appropriately
+                let elem_typ_tokens = {
+                    let mut tokens = genco::Tokens::<genco::lang::Go>::new();
+                    go_type.format_into(&mut tokens);
+                    tokens.to_string().unwrap()
+                };
+                let typ = &elem_typ_tokens;
+
+                quote_in! { self.body =>
+                    $['\r']
+                    $base := $base_operand
+                    $len := $len_operand
+                    $result := make([]$typ, $len)
+                    for $idx := uint32(0); $idx < $len; $idx++ {
+                        base := $base + $idx * $size
+                        $body
+                        $result[$idx] = $body_result
+                    }
+                };
+                results.push(Operand::SingleValue(result.into()));
+            }
+            Instruction::ListLower { element, .. } => {
+                let (body, _) = self.pop_block();
+                let tmp = self.tmp();
+                let vec = &format!("vec{tmp}");
+                let result = &format!("result{tmp}");
+                let err = &format!("err{tmp}");
+                let default = &format!("default{tmp}");
+                let ptr = &format!("ptr{tmp}");
+                let len = &format!("len{tmp}");
+                let iter_element = "e";
+                let iter_base = "base";
+                let operand = &operands[0];
+                let size = self.sizes.size(element).size_wasm32();
+                let align = self.sizes.align(element).align_wasm32();
+
+                quote_in! { self.body =>
+                    $['\r']
+                    $vec := $operand
+                    $len := uint64(len($vec))
+                    $result, $err := i.module.ExportedFunction("cabi_realloc").Call(ctx, 0, 0, $align, $len * $size)
+                    $(match &self.result {
+                        GoResult::Anon(GoType::ValueOrError(typ)) => {
+                            if $err != nil {
+                                var $default $(typ.as_ref())
+                                return $default, $err
+                            }
+                        }
+                        GoResult::Anon(GoType::Error) => {
+                            if $err != nil {
+                                return $err
+                            }
+                        }
+                        GoResult::Anon(_) | GoResult::Empty => {
+                            if $err != nil {
+                                panic($err)
+                            }
+                        }
+                    })
+                    $ptr := $result[0]
+                    for idx := uint64(0); idx < $len; idx++ {
+                        $iter_element := $vec[idx]
+                        $iter_base := uint32($ptr + uint64(idx) * uint64($size))
+                        $body
+                    }
+                };
+                results.push(Operand::SingleValue(ptr.into()));
+                results.push(Operand::SingleValue(len.into()));
+            }
+            Instruction::CallWasm { name, .. } => {
+                let tmp = self.tmp();
+                let raw = &format!("raw{tmp}");
+                let ret = &format!("results{tmp}");
+                let err = &format!("err{tmp}");
+                if operands.is_empty() {
+                    quote_in! { self.body =>
+                        $['\r']
+                        $raw, $err := i.module.ExportedFunction($(quoted(*name))).Call(ctx)
+                        $(&self.go_imports.fmt)("DEBUG: CallWasm %s -> raw=%v, err=%v\n", $(quoted(*name)), $raw, $err)
+                        $['\r']
+                    };
+                } else {
+                    quote_in! { self.body =>
+                        $['\r']
+                        $raw, $err := i.module.ExportedFunction($(quoted(*name))).Call(ctx, $(for op in operands.iter() join (, ) => uint64($op)))
+                        $(&self.go_imports.fmt)("DEBUG: CallWasm %s -> raw=%v, err=%v\n", $(quoted(*name)), $raw, $err)
+                        $['\r']
+                    };
+                }
+                quote_in! { self.body =>
+                    if $err != nil {
+                        panic($err)
+                    }
+                    $ret := $raw[0]
+                    $(&self.go_imports.fmt)("DEBUG: Extracted result -> %d\n", $ret)
+                };
+                results.push(Operand::SingleValue(ret.into()));
+            }
+            Instruction::CallInterface { .. } => {
+                // TODO: Implement CallInterface for exports
+                let tmp = self.tmp();
+                let result = &format!("result{tmp}");
+                quote_in! { self.body =>
+                    $['\r']
+                    $result := callInterface() // TODO: CallInterface not implemented
+                };
+                results.push(Operand::SingleValue(result.into()));
+            }
+            Instruction::TupleLift { .. } => {
+                // For now, just pass through the operands
+                for operand in operands.iter() {
+                    results.push(operand.clone());
+                }
+            }
+            Instruction::RecordLower { record, .. } => {
+                let tmp = self.tmp();
+                let operand = &operands[0];
+                for field in record.fields.iter() {
+                    let struct_field = GoIdentifier::Public { name: &field.name };
+                    let var_name = format!("{}{tmp}", &field.name);
+                    let var_identifier = GoIdentifier::Private { name: &var_name };
+                    quote_in! { self.body =>
+                        $['\r']
+                        $var_identifier := $operand.$struct_field
+                    }
+                    // Use the formatted version (lowerCamelCase) for the operand
+                    let formatted_var_name = var_name.to_lower_camel_case();
+                    results.push(Operand::SingleValue(formatted_var_name))
+                }
+            }
+            Instruction::TupleLower { .. } => {
+                for operand in operands.iter() {
+                    results.push(operand.clone());
+                }
+            }
+            Instruction::EnumLower { .. } => {
+                let operand = operands.pop().unwrap();
+                results.push(operand);
+            }
+            Instruction::EnumLift { .. } => {
+                let disc = operands.pop().unwrap();
+                results.push(disc);
+            }
+
+            Instruction::VariantLift { .. } => {
+                let disc = operands.pop().unwrap();
+                results.push(disc);
+            }
+            Instruction::OptionLower { .. } => {
+                let some = operands.pop().unwrap();
+                let is_some = operands.pop().unwrap();
+                results.push(is_some);
+                results.push(some);
+            }
+            Instruction::ResultLift { result, .. } => {
+                eprintln!("DEBUG: Processing ResultLift instruction");
+                eprintln!("  result type: {:?}", result);
+
+                use wit_bindgen_core::wit_parser::{Result_, Type};
+
+                match result {
+                    Result_ {
+                        ok: Some(typ),
+                        err: Some(Type::String),
+                    } => {
+                        // Pop blocks in the order they were pushed (err first, then ok)
+                        let (err_block, err_results) = self.blocks.pop().unwrap();
+                        let (ok_block, ok_results) = self.blocks.pop().unwrap();
+
+                        let tmp = self.tmp();
+                        let value = &format!("value{}", tmp);
+                        let err = &format!("err{}", tmp);
+                        let tag = &operands[0];
+
+                        let ok_type = crate::resolve_type(typ, resolve).unwrap();
+
+                        // Get the operands to assign from
+                        let ok_op = if ok_results.is_empty() {
+                            &Operand::Literal("\"\"".into())
+                        } else {
+                            &ok_results[0]
+                        };
+
+                        let err_op = if err_results.is_empty() {
+                            &Operand::Literal("\"\"".into())
+                        } else {
+                            &err_results[0]
+                        };
+
+                        quote_in! { self.body =>
+                            $['\r']
+                            var $value $ok_type
+                            var $err error
+                            $(&self.go_imports.fmt)("DEBUG: ResultLift switch discriminant = %d\n", $tag)
+                            switch $tag {
+                            case 0:
+                                $(&self.go_imports.fmt)("DEBUG: Taking OK branch\n")
+                                $ok_block
+                                $value = $ok_op
+                            case 1:
+                                $(&self.go_imports.fmt)("DEBUG: Taking Err branch\n")
+                                $err_block
+                                $err = $(&self.go_imports.errors)($err_op)
+                            default:
+                                $err = $(&self.go_imports.errors)("invalid variant discriminant for expected")
+                            }
+                        };
+
+                        results.push(Operand::MultiValue((value.clone(), err.clone())));
+                    }
+                    Result_ {
+                        ok: None,
+                        err: Some(Type::String),
+                    } => {
+                        // Pop blocks in the order they were pushed (err first, then ok)
+                        let (err_block, err_results) = self.blocks.pop().unwrap();
+                        let (ok_block, _ok_results) = self.blocks.pop().unwrap();
+
+                        let tmp = self.tmp();
+                        let err = &format!("err{}", tmp);
+                        let tag = &operands[0];
+
+                        let err_op = if err_results.is_empty() {
+                            &Operand::Literal("\"\"".into())
+                        } else {
+                            &err_results[0]
+                        };
+
+                        quote_in! { self.body =>
+                            $['\r']
+                            var $err error
+                            $(&self.go_imports.fmt)("DEBUG: ResultLift (no ok) switch discriminant = %d\n", $tag)
+                            switch $tag {
+                            case 0:
+                                $(&self.go_imports.fmt)("DEBUG: Taking OK branch (no value)\n")
+                                $ok_block
+                            case 1:
+                                $(&self.go_imports.fmt)("DEBUG: Taking Err branch (no ok value)\n")
+                                $err_block
+                                $err = $(&self.go_imports.errors)($err_op)
+                            default:
+                                $err = $(&self.go_imports.errors)("invalid variant discriminant for expected")
+                            }
+                        };
+
+                        results.push(Operand::SingleValue(err.clone()));
+                    }
+                    _ => {
+                        quote_in! { self.body =>
+                            $['\r']
+                            // TODO: Implement ResultLift for $result
+                        };
+                        results.push(Operand::SingleValue("result_not_implemented".into()));
+                    }
+                }
+
+                eprintln!("  results.len() after = {}", results.len());
+            }
+            Instruction::ResultLower { .. } => {
+                for operand in operands.iter() {
+                    results.push(operand.clone());
+                }
+            }
+            // Union instructions removed in newer versions of wit-bindgen-core
+            Instruction::HandleLower { .. } | Instruction::HandleLift { .. } => {
+                let handle = &operands[0];
+                results.push(handle.clone());
+            }
+            // These instructions removed in newer versions of wit-bindgen-core
+            Instruction::Bitcasts { .. } => {
+                let operand = &operands[0];
+                results.push(operand.clone());
+            }
+            Instruction::Flush { amt } => {
+                eprintln!("DEBUG: Processing Flush instruction with amt = {}", amt);
+                eprintln!("  operands.len() = {}", operands.len());
+
+                for n in 0..*amt {
+                    if let Some(op) = operands.get(n) {
+                        results.push(op.clone());
+                    } else {
+                        // Push placeholder value
+                        let placeholder = format!("flush_{}", n);
+                        results.push(Operand::SingleValue(placeholder));
+                    }
+                }
+
+                eprintln!("  results.len() after = {}", results.len());
+            }
+            Instruction::OptionLift { payload, .. } => {
+                eprintln!(
+                    "DEBUG: Processing OptionLift instruction, payload: {:?}",
+                    payload
+                );
+                eprintln!("  operands.len() = {}", operands.len());
+                eprintln!("  results.len() before = {}", results.len());
+                eprintln!("  blocks.len() = {}", self.blocks.len());
+
+                // Pop blocks in the order: some first, then none
+                let (some_block, some_results) = self.blocks.pop().unwrap();
+                let (none_block, _none_results) = self.blocks.pop().unwrap();
+
+                let tmp = self.tmp();
+                let result = &format!("result{}", tmp);
+                let ok = &format!("ok{}", tmp);
+                let op = &operands[0];
+
+                // Generate proper Go type for the payload using resolve_type
+                let go_type = crate::resolve_type(payload, resolve).unwrap();
+
+                // For quote interpolation, we need to format the GoType appropriately
+                let typ_tokens = {
+                    let mut tokens = genco::Tokens::<genco::lang::Go>::new();
+                    go_type.format_into(&mut tokens);
+                    tokens.to_string().unwrap()
+                };
+                let typ = &typ_tokens;
+
+                let some_result_op = if some_results.is_empty() {
+                    &Operand::Literal("false".into()) // Default value for the type
+                } else {
+                    &some_results[0]
+                };
+
+                quote_in! { self.body =>
+                    $['\r']
+                    var $result $typ
+                    var $ok bool
+                    if $op == 0 {
+                        $none_block
+                        $ok = false
+                    } else {
+                        $some_block
+                        $ok = true
+                        $result = $some_result_op
+                    }
+                };
+
+                results.push(Operand::MultiValue((result.clone(), ok.clone())));
+
+                eprintln!("  results.len() after = {}", results.len());
+            }
+            Instruction::Return { amt, .. } => {
+                eprintln!("DEBUG: Processing Return instruction with amt = {}", amt);
+                // Return consumes operands but doesn't produce results
+                if *amt > 0 {
+                    let operand = &operands[0];
+                    quote_in! { self.body =>
+                        $['\r']
+                        return $operand
+                    };
+                }
+                // Return produces no results
+            }
+            Instruction::I32Load8U { offset } => {
+                let ptr = &operands[0];
+                let tmp = self.tmp();
+                let value = &format!("value{tmp}");
+                let ok = &format!("ok{tmp}");
+                eprintln!(
+                    "DEBUG: I32Load8U operand ptr = {:?}, offset = {:?}",
+                    ptr, offset
+                );
+
+                // Convert ArchitectureSize offset to Go expression
+                let offset_expr = {
+                    let offset_debug = format!("{:?}", offset);
+                    if offset_debug == "0" {
+                        "0".to_string()
+                    } else if offset_debug.contains("ptrsz") {
+                        if offset_debug.contains("(2*ptrsz)") {
+                            "8".to_string()
+                        } else {
+                            offset_debug.replace("ptrsz", "4")
+                        }
+                    } else {
+                        // For literal numbers like "1"
+                        offset_debug
+                    }
+                };
+
+                quote_in! { self.body =>
+                    $['\r']
+                    $value, $ok := i.module.Memory().ReadByte(uint32($ptr + $(offset_expr.clone())))
+                    $(&self.go_imports.fmt)("DEBUG: ReadByte at ptr=%d+%s -> value=%d, ok=%v\n", $ptr, $(quoted(&offset_expr)), $value, $ok)
+                    if !$ok {
+                        panic($(&self.go_imports.errors)("failed to read byte from memory"))
+                    }
+                };
+                results.push(Operand::SingleValue(value.into()));
+            }
+            Instruction::PointerLoad { offset } => {
+                let ptr = &operands[0];
+                let tmp = self.tmp();
+                let value = &format!("value{tmp}");
+                let ok = &format!("ok{tmp}");
+                eprintln!(
+                    "DEBUG: PointerLoad operand ptr = {:?}, offset = {:?}",
+                    ptr, offset
+                );
+
+                // Convert ArchitectureSize offset to Go expression
+                let offset_expr = {
+                    let offset_debug = format!("{:?}", offset);
+                    if offset_debug == "0" {
+                        "0".to_string()
+                    } else if offset_debug.contains("ptrsz") {
+                        if offset_debug.contains("(2*ptrsz)") {
+                            "8".to_string()
+                        } else {
+                            offset_debug.replace("ptrsz", "4")
+                        }
+                    } else {
+                        // For literal numbers
+                        offset_debug
+                    }
+                };
+
+                quote_in! { self.body =>
+                    $['\r']
+                    $value, $ok := i.module.Memory().ReadUint32Le(uint32($ptr + $(offset_expr.clone())))
+                    $(&self.go_imports.fmt)("DEBUG: ReadUint32Le at ptr=%d+%s -> value=%d, ok=%v\n", $ptr, $(quoted(&offset_expr)), $value, $ok)
+                    if !$ok {
+                        panic($(&self.go_imports.errors)("failed to read pointer from memory"))
+                    }
+                };
+                results.push(Operand::SingleValue(value.into()));
+            }
+            Instruction::LengthLoad { offset } => {
+                let ptr = &operands[0];
+                let tmp = self.tmp();
+                let value = &format!("value{tmp}");
+                let ok = &format!("ok{tmp}");
+                eprintln!(
+                    "DEBUG: LengthLoad operand ptr = {:?}, offset = {:?}",
+                    ptr, offset
+                );
+
+                // Convert ArchitectureSize offset to Go expression
+                let offset_expr = {
+                    let offset_debug = format!("{:?}", offset);
+                    if offset_debug == "0" {
+                        "0".to_string()
+                    } else if offset_debug.contains("ptrsz") {
+                        if offset_debug.contains("(2*ptrsz)") {
+                            "8".to_string()
+                        } else {
+                            offset_debug.replace("ptrsz", "4")
+                        }
+                    } else {
+                        // For literal numbers
+                        offset_debug
+                    }
+                };
+
+                quote_in! { self.body =>
+                    $['\r']
+                    $value, $ok := i.module.Memory().ReadUint32Le(uint32($ptr + $(offset_expr.clone())))
+                    $(&self.go_imports.fmt)("DEBUG: ReadUint32Le (length) at ptr=%d+%s -> value=%d, ok=%v\n", $ptr, $(quoted(&offset_expr)), $value, $ok)
+                    if !$ok {
+                        panic($(&self.go_imports.errors)("failed to read length from memory"))
+                    }
+                };
+                results.push(Operand::SingleValue(value.into()));
+            }
+            Instruction::IterElem { .. } => {
+                results.push(Operand::SingleValue("e".into()));
+            }
+            Instruction::IterBasePointer => {
+                results.push(Operand::SingleValue("base".into()));
+            }
+            Instruction::F32Store { offset } => {
+                let tag = &operands[0];
+                let ptr = &operands[1];
+
+                // Convert ArchitectureSize offset to Go expression
+                let offset_expr = {
+                    let offset_debug = format!("{:?}", offset);
+                    if offset_debug == "0" {
+                        "0".to_string()
+                    } else if offset_debug.contains("ptrsz") {
+                        if offset_debug.contains("(2*ptrsz)") {
+                            "8".to_string()
+                        } else {
+                            offset_debug.replace("ptrsz", "4")
+                        }
+                    } else {
+                        offset_debug
+                    }
+                };
+
+                quote_in! { self.body =>
+                    $['\r']
+                    i.module.Memory().WriteUint64Le($ptr + $(offset_expr), $tag)
+                };
+                // Store instructions don't produce results
+            }
+            Instruction::F64Store { offset } => {
+                let tag = &operands[0];
+                let ptr = &operands[1];
+
+                // Convert ArchitectureSize offset to Go expression
+                let offset_expr = {
+                    let offset_debug = format!("{:?}", offset);
+                    if offset_debug == "0" {
+                        "0".to_string()
+                    } else if offset_debug.contains("ptrsz") {
+                        if offset_debug.contains("(2*ptrsz)") {
+                            "8".to_string()
+                        } else {
+                            offset_debug.replace("ptrsz", "4")
+                        }
+                    } else {
+                        offset_debug
+                    }
+                };
+
+                quote_in! { self.body =>
+                    $['\r']
+                    i.module.Memory().WriteUint64Le($ptr + $(offset_expr), $tag)
+                };
+                // Store instructions don't produce results
+            }
+            Instruction::I32Store { offset } => {
+                let tag = &operands[0];
+                let ptr = &operands[1];
+
+                // Convert ArchitectureSize offset to Go expression
+                let offset_expr = {
+                    let offset_debug = format!("{:?}", offset);
+                    if offset_debug == "0" {
+                        "0".to_string()
+                    } else if offset_debug.contains("ptrsz") {
+                        if offset_debug.contains("(2*ptrsz)") {
+                            "8".to_string()
+                        } else {
+                            offset_debug.replace("ptrsz", "4")
+                        }
+                    } else {
+                        offset_debug
+                    }
+                };
+
+                quote_in! { self.body =>
+                    $['\r']
+                    i.module.Memory().WriteUint32Le($ptr + $(offset_expr), $tag)
+                };
+                // Store instructions don't produce results
+            }
+            Instruction::I32Store8 { offset } => {
+                let tag = &operands[0];
+                let ptr = &operands[1];
+
+                // Convert ArchitectureSize offset to Go expression
+                let offset_expr = {
+                    let offset_debug = format!("{:?}", offset);
+                    if offset_debug == "0" {
+                        "0".to_string()
+                    } else if offset_debug.contains("ptrsz") {
+                        if offset_debug.contains("(2*ptrsz)") {
+                            "8".to_string()
+                        } else {
+                            offset_debug.replace("ptrsz", "4")
+                        }
+                    } else {
+                        offset_debug
+                    }
+                };
+
+                quote_in! { self.body =>
+                    $['\r']
+                    i.module.Memory().WriteByte($ptr + $(offset_expr), $tag)
+                };
+                // Store instructions don't produce results
+            }
+            Instruction::F32Load { offset } => {
+                let tmp = self.tmp();
+                let value = &format!("value{tmp}");
+                let ok = &format!("ok{tmp}");
+                let operand = &operands[0];
+
+                // Convert ArchitectureSize offset to Go expression
+                let offset_expr = {
+                    let offset_debug = format!("{:?}", offset);
+                    if offset_debug == "0" {
+                        "0".to_string()
+                    } else if offset_debug.contains("ptrsz") {
+                        if offset_debug.contains("(2*ptrsz)") {
+                            "8".to_string()
+                        } else {
+                            offset_debug.replace("ptrsz", "4")
+                        }
+                    } else {
+                        offset_debug
+                    }
+                };
+
+                quote_in! { self.body =>
+                    $['\r']
+                    $value, $ok := i.module.Memory().ReadUint64Le(uint32($operand + $(offset_expr)))
+                    if !$ok {
+                        panic($(&self.go_imports.errors)("failed to read f32 from memory"))
+                    }
+                };
+                results.push(Operand::SingleValue(value.into()));
+            }
+            Instruction::F64Load { offset } => {
+                let tmp = self.tmp();
+                let value = &format!("value{tmp}");
+                let ok = &format!("ok{tmp}");
+                let operand = &operands[0];
+
+                // Convert ArchitectureSize offset to Go expression
+                let offset_expr = {
+                    let offset_debug = format!("{:?}", offset);
+                    if offset_debug == "0" {
+                        "0".to_string()
+                    } else if offset_debug.contains("ptrsz") {
+                        if offset_debug.contains("(2*ptrsz)") {
+                            "8".to_string()
+                        } else {
+                            offset_debug.replace("ptrsz", "4")
+                        }
+                    } else {
+                        offset_debug
+                    }
+                };
+
+                quote_in! { self.body =>
+                    $['\r']
+                    $value, $ok := i.module.Memory().ReadUint64Le(uint32($operand + $(offset_expr)))
+                    if !$ok {
+                        panic($(&self.go_imports.errors)("failed to read f64 from memory"))
+                    }
+                };
+                results.push(Operand::SingleValue(value.into()));
+            }
+            Instruction::I32Load { offset } => {
+                let tmp = self.tmp();
+                let value = &format!("value{tmp}");
+                let ok = &format!("ok{tmp}");
+                let operand = &operands[0];
+
+                // Convert ArchitectureSize offset to Go expression
+                let offset_expr = {
+                    let offset_debug = format!("{:?}", offset);
+                    if offset_debug == "0" {
+                        "0".to_string()
+                    } else if offset_debug.contains("ptrsz") {
+                        if offset_debug.contains("(2*ptrsz)") {
+                            "8".to_string()
+                        } else {
+                            offset_debug.replace("ptrsz", "4")
+                        }
+                    } else {
+                        offset_debug
+                    }
+                };
+
+                quote_in! { self.body =>
+                    $['\r']
+                    $value, $ok := i.module.Memory().ReadUint32Le(uint32($operand + $(offset_expr)))
+                    if !$ok {
+                        panic($(&self.go_imports.errors)("failed to read i32 from memory"))
+                    }
+                };
+                results.push(Operand::SingleValue(value.into()));
+            }
+            Instruction::I64Load { offset } => {
+                let tmp = self.tmp();
+                let value = &format!("value{tmp}");
+                let ok = &format!("ok{tmp}");
+                let operand = &operands[0];
+
+                // Convert ArchitectureSize offset to Go expression
+                let offset_expr = {
+                    let offset_debug = format!("{:?}", offset);
+                    if offset_debug == "0" {
+                        "0".to_string()
+                    } else if offset_debug.contains("ptrsz") {
+                        if offset_debug.contains("(2*ptrsz)") {
+                            "8".to_string()
+                        } else {
+                            offset_debug.replace("ptrsz", "4")
+                        }
+                    } else {
+                        offset_debug
+                    }
+                };
+
+                quote_in! { self.body =>
+                    $['\r']
+                    $value, $ok := i.module.Memory().ReadUint64Le(uint32($operand + $(offset_expr)))
+                    if !$ok {
+                        panic($(&self.go_imports.errors)("failed to read i64 from memory"))
+                    }
+                };
+                results.push(Operand::SingleValue(value.into()));
+            }
+            Instruction::RecordLift { record, name, .. } => {
+                let tmp = self.tmp();
+                let value = &format!("value{tmp}");
+
+                // Generate pointer conversion code for optional fields
+                let converted_operands: Vec<_> = record
+                    .fields
+                    .iter()
+                    .zip(operands)
+                    .enumerate()
+                    .map(|(i, (field, op))| {
+                        let field_type = match crate::resolve_type(&field.ty, resolve).unwrap() {
+                            gravity_go::GoType::ValueOrOk(inner_type) => {
+                                gravity_go::GoType::Pointer(inner_type)
+                            }
+                            other => other,
+                        };
+                        let op_clone = op.clone();
+                        match (&field_type, &op_clone) {
+                            (
+                                gravity_go::GoType::Pointer(inner_type),
+                                Operand::MultiValue((val, ok)),
+                            ) => {
+                                let ptr_var_name = format!("ptr{tmp}x{i}");
+                                let val_ident = GoIdentifier::Local { name: val };
+                                let ok_ident = GoIdentifier::Local { name: ok };
+                                let ptr_var_ident = GoIdentifier::Local {
+                                    name: &ptr_var_name,
+                                };
+                                quote_in! { self.body =>
+                                    $['\r']
+                                    var $(&ptr_var_ident) *$(inner_type.as_ref())
+                                    if $(&ok_ident) {
+                                        $(&ptr_var_ident) = &$(&val_ident)
+                                    } else {
+                                        $(&ptr_var_ident) = nil
+                                    }
+                                };
+                                Operand::SingleValue(ptr_var_name)
+                            }
+                            _ => op_clone,
+                        }
+                    })
+                    .collect();
+
+                let fields = record
+                    .fields
+                    .iter()
+                    .zip(&converted_operands)
+                    .map(|(field, op)| (GoIdentifier::Public { name: &field.name }, op));
+
+                quote_in! { self.body =>
+                    $['\r']
+                    $value := $(GoIdentifier::Public { name }){
+                        $(for (name, op) in fields join ($['\r']) => $name: $op,)
+                    }
+                };
+                results.push(Operand::SingleValue(value.into()));
+            }
+            Instruction::LengthStore { offset } => {
+                let offset = offset.size_wasm32();
+                let len = &operands[0];
+                let ptr = &operands[1];
+                quote_in! { self.body =>
+                    $['\r']
+                    i.module.Memory().WriteUint32Le($ptr+$offset, uint32($len))
+                };
+            }
+            Instruction::PointerStore { offset } => {
+                let offset = offset.size_wasm32();
+                let value = &operands[0];
+                let ptr = &operands[1];
+                quote_in! { self.body =>
+                    $['\r']
+                    i.module.Memory().WriteUint32Le($ptr+$offset, uint32($value))
+                };
+            }
+            Instruction::VariantPayloadName => {
+                results.push(Operand::SingleValue("variantPayload".into()));
+            }
+            Instruction::I32Const { val } => {
+                results.push(Operand::Literal(val.to_string()));
+            }
+            Instruction::VariantLower {
+                variant,
+                results: result_types,
+                ..
+            } => {
+                let blocks = self
+                    .blocks
+                    .drain(self.blocks.len() - variant.cases.len()..)
+                    .collect::<Vec<_>>();
+                let tmp = self.tmp_counter;
+                self.tmp_counter += 1;
+                let value = &operands[0];
+                let default = &format!("default{tmp}");
+
+                for (i, _typ) in result_types.iter().enumerate() {
+                    let variant_item = &format!("variant{tmp}_{i}");
+                    quote_in! { self.body =>
+                        $['\r']
+                        var $variant_item uint64
+                    };
+                    results.push(Operand::SingleValue(variant_item.into()));
+                }
+
+                // Find the parent variant's name by comparing case names
+                let variant_name = resolve.types.iter().find_map(|(_, type_def)| {
+                    if let wit_bindgen_core::wit_parser::TypeDefKind::Variant(v) = &type_def.kind {
+                        // Compare case names to identify the matching variant
+                        if v.cases.len() == variant.cases.len()
+                            && v.cases
+                                .iter()
+                                .zip(variant.cases.iter())
+                                .all(|(a, b)| a.name == b.name)
+                        {
+                            type_def.name.as_ref()
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    }
+                });
+
+                let variant_name = match variant_name {
+                    Some(name) => name,
+                    None => {
+                        eprintln!("Warning: Could not find variant name, using 'Unknown'");
+                        "Unknown"
+                    }
+                };
+
+                // Pre-generate all prefixed case names to handle string lifetimes
+                let case_names: Vec<String> = variant
+                    .cases
+                    .iter()
+                    .map(|case| {
+                        let capitalized_case = case
+                            .name
+                            .replace("-", " ")
+                            .split_whitespace()
+                            .map(|word| {
+                                let mut chars = word.chars();
+                                match chars.next() {
+                                    None => String::new(),
+                                    Some(first) => {
+                                        first.to_uppercase().collect::<String>()
+                                            + &chars.collect::<String>()
+                                    }
+                                }
+                            })
+                            .collect::<String>();
+                        format!("{}{}", variant_name, capitalized_case)
+                    })
+                    .collect();
+
+                let mut cases: Tokens<Go> = Tokens::new();
+                for ((_case, prefixed_name), (block, block_results)) in
+                    variant.cases.iter().zip(&case_names).zip(blocks)
+                {
+                    let mut assignments: Tokens<Go> = Tokens::new();
+                    for (i, result) in block_results.iter().enumerate() {
+                        let variant_item = &format!("variant{tmp}_{i}");
+                        quote_in! { assignments =>
+                            $['\r']
+                            $variant_item = $result
+                        };
+                    }
+
+                    let name = GoIdentifier::Public {
+                        name: prefixed_name,
+                    };
+                    quote_in! { cases =>
+                        $['\r']
+                        case $name:
+                            $block
+                            $assignments
+                    }
+                }
+
+                quote_in! { self.body =>
+                    $['\r']
+                    switch variantPayload := $value.(type) {
+                        $cases
+                        default:
+                            var $default Output
+                            return $default, errors.New("invalid variant type provided")
+                    }
+                };
+            }
+            _ => {
+                eprintln!("DEBUG: Unhandled instruction: {:?}", inst);
+                eprintln!(
+                    "DEBUG: Unhandled discriminant: {:?}",
+                    std::mem::discriminant(inst)
+                );
+                eprintln!("DEBUG: This instruction was not implemented!");
+                quote_in! { self.body =>
+                    $['\r']
+                    // TODO: Implement instruction $(format!("{:?}", inst))
+                };
+                // For unhandled instructions, pass through operands as results
+                for operand in operands {
+                    results.push(operand.clone());
+                }
+            }
+        }
+    }
+
+    fn sizes(&self) -> &SizeAlign {
+        &self.sizes
+    }
+
+    fn push_block(&mut self) {
+        eprintln!("DEBUG: push_block called");
+        let prev = std::mem::replace(&mut self.body, Tokens::new());
+        self.block_storage.push(prev);
+    }
+
+    fn finish_block(&mut self, operands: &mut Vec<Self::Operand>) {
+        eprintln!(
+            "DEBUG: finish_block called, results.len() before = {}",
+            operands.len()
+        );
+        let to_restore = self.block_storage.pop().expect("should have body");
+        let src = std::mem::replace(&mut self.body, to_restore);
+        let operands_copy = std::mem::take(operands);
+
+        eprintln!("DEBUG: block has body and {} results", operands_copy.len());
+
+        self.blocks.push((src, operands_copy));
+        eprintln!("DEBUG: finish_block done, results.len() after = 0");
+    }
+}

--- a/crates/gravity-codegen/src/factory.rs
+++ b/crates/gravity-codegen/src/factory.rs
@@ -1,0 +1,271 @@
+use anyhow::Result;
+use genco::prelude::*;
+use gravity_go::{Go, GoIdentifier};
+use std::collections::BTreeMap;
+
+use crate::context::GenerationContext;
+use crate::imports::GoImports;
+
+/// Configuration for factory generation
+pub struct FactoryConfig<'a> {
+    pub world_name: &'a str,
+    pub go_imports: &'a GoImports,
+    pub interface_params: Vec<String>,
+    pub import_chains: BTreeMap<String, Tokens<Go>>,
+    pub wasm_var_name: &'a GoIdentifier<'a>,
+}
+
+/// Generator for factory and instance types
+pub struct FactoryGenerator<'a> {
+    context: &'a mut GenerationContext,
+    config: FactoryConfig<'a>,
+}
+
+impl<'a> FactoryGenerator<'a> {
+    pub fn new(context: &'a mut GenerationContext, config: FactoryConfig<'a>) -> Self {
+        Self { context, config }
+    }
+
+    /// Generate factory and instance types and methods
+    pub fn generate(mut self) -> Result<()> {
+        let world_name = self.config.world_name;
+
+        // Create identifiers
+        let factory = GoIdentifier::Public {
+            name: &format!("{world_name}-factory"),
+        };
+        let instance_name = GoIdentifier::Public {
+            name: &format!("{world_name}-instance"),
+        };
+        let new_factory = GoIdentifier::Public {
+            name: &format!("new-{world_name}-factory"),
+        };
+        let instance = GoIdentifier::Public {
+            name: &format!("{world_name}-instance"),
+        };
+
+        // Generate factory and instance struct types
+        self.generate_types(&factory, &instance_name)?;
+
+        // Generate factory constructor
+        self.generate_factory_constructor(&factory, &new_factory)?;
+
+        // Generate instance methods
+        self.generate_instance_methods(&factory, &instance)?;
+
+        Ok(())
+    }
+
+    /// Generate factory and instance struct definitions
+    fn generate_types(
+        &mut self,
+        factory: &GoIdentifier,
+        instance_name: &GoIdentifier,
+    ) -> Result<()> {
+        let go_imports = self.config.go_imports;
+
+        quote_in! { self.context.out =>
+            $['\n']
+            type $factory struct {
+                runtime $(&go_imports.wazero_runtime)
+                module  $(&go_imports.wazero_compiled_module)
+            }
+            $['\n']
+            type $instance_name struct {
+                module $(&go_imports.wazero_api_module)
+            }
+            $['\n']
+        };
+
+        Ok(())
+    }
+
+    /// Generate the factory constructor function
+    fn generate_factory_constructor(
+        &mut self,
+        factory: &GoIdentifier,
+        new_factory: &GoIdentifier,
+    ) -> Result<()> {
+        let go_imports = self.config.go_imports;
+        let wasm_var_name = self.config.wasm_var_name;
+
+        // Build the parameter list
+        let params = self.build_parameters()?;
+
+        quote_in! { self.context.out =>
+            func $new_factory(
+                $['\r']
+                $params
+                $['\r']
+            ) (*$factory, error) {
+                wazeroRuntime := $(&go_imports.wazero_new_runtime)(ctx)
+
+                $(for chain in self.config.import_chains.values() =>
+                    $chain
+                    $['\r']
+                )
+
+                module, err := wazeroRuntime.CompileModule(ctx, $wasm_var_name)
+                if err != nil {
+                    return nil, err
+                }
+                return &$factory{
+                    runtime: wazeroRuntime,
+                    module:  module,
+                }, nil
+            }
+            $['\n']
+        };
+
+        Ok(())
+    }
+
+    /// Build parameter list for factory constructor
+    fn build_parameters(&self) -> Result<Tokens<Go>> {
+        let go_imports = self.config.go_imports;
+        let world_name = self.config.world_name;
+        let interface_params = &self.config.interface_params;
+
+        Ok(quote! {
+            ctx $(&go_imports.context),
+            $(for interface_name in interface_params.iter() =>
+            $(GoIdentifier::Local { name: interface_name }) $(GoIdentifier::Public { name: &format!("i-{world_name}-{interface_name}")}),)
+        })
+    }
+
+    /// Generate instance methods (Instantiate, Close, etc.)
+    fn generate_instance_methods(
+        &mut self,
+        factory: &GoIdentifier,
+        instance: &GoIdentifier,
+    ) -> Result<()> {
+        let go_imports = self.config.go_imports;
+
+        quote_in! { self.context.out =>
+            func (f *$factory) Instantiate(ctx $(&go_imports.context)) (*$instance, error) {
+                module, err := f.runtime.InstantiateModule(ctx, f.module, $(&go_imports.wazero_new_module_config)())
+                if err != nil {
+                    return nil, err
+                }
+                return &$instance{module: module}, nil
+            }
+            $['\n']
+            func (f *$factory) Close(ctx $(&go_imports.context)) error {
+                return f.runtime.Close(ctx)
+            }
+            $['\n']
+            func (i *$instance) Close(ctx $(&go_imports.context)) error {
+                return i.module.Close(ctx)
+            }
+        };
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_factory_generation() {
+        let mut context = GenerationContext::new();
+        let go_imports = GoImports::new();
+        let wasm_var_name = GoIdentifier::Private {
+            name: "wasm-file-test",
+        };
+
+        let config = FactoryConfig {
+            world_name: "test",
+            go_imports: &go_imports,
+            interface_params: vec!["logger".to_string()],
+            import_chains: BTreeMap::new(),
+            wasm_var_name: &wasm_var_name,
+        };
+
+        let generator = FactoryGenerator::new(&mut context, config);
+        let result = generator.generate();
+
+        assert!(result.is_ok());
+
+        // Format the output to check the generated code
+        let mut writer = genco::fmt::FmtWriter::new(String::new());
+        let fmt =
+            genco::fmt::Config::from_lang::<Go>().with_indentation(genco::fmt::Indentation::Tab);
+        let config = genco::lang::go::Config::default();
+
+        context
+            .out
+            .format_file(&mut writer.as_formatter(&fmt), &config)
+            .unwrap();
+
+        let output_str = writer.into_inner();
+
+        // Should contain factory struct
+        assert!(output_str.contains("type TestFactory struct"));
+
+        // Should contain instance struct
+        assert!(output_str.contains("type TestInstance struct"));
+
+        // Should contain factory constructor
+        assert!(output_str.contains("func NewTestFactory"));
+
+        // Should contain Instantiate method
+        assert!(output_str.contains("func (f *TestFactory) Instantiate"));
+    }
+
+    #[test]
+    fn test_factory_with_interfaces() {
+        let mut context = GenerationContext::new();
+        let go_imports = GoImports::new();
+        let wasm_var_name = GoIdentifier::Private {
+            name: "wasm-file-basic",
+        };
+
+        // Create a sample import chain
+        let mut import_chains = BTreeMap::new();
+        import_chains.insert(
+            "test-module".to_string(),
+            quote! {
+                _, err := wazeroRuntime.NewHostModuleBuilder("test-module").
+                Instantiate(ctx)
+                if err != nil {
+                    return nil, err
+                }
+            },
+        );
+
+        let config = FactoryConfig {
+            world_name: "basic",
+            go_imports: &go_imports,
+            interface_params: vec!["logger".to_string(), "storage".to_string()],
+            import_chains,
+            wasm_var_name: &wasm_var_name,
+        };
+
+        let generator = FactoryGenerator::new(&mut context, config);
+        let result = generator.generate();
+
+        assert!(result.is_ok());
+
+        // Format the output to check the generated code
+        let mut writer = genco::fmt::FmtWriter::new(String::new());
+        let fmt =
+            genco::fmt::Config::from_lang::<Go>().with_indentation(genco::fmt::Indentation::Tab);
+        let config = genco::lang::go::Config::default();
+
+        context
+            .out
+            .format_file(&mut writer.as_formatter(&fmt), &config)
+            .unwrap();
+
+        let output_str = writer.into_inner();
+
+        // Should have interface parameters in constructor
+        assert!(output_str.contains("logger IBasicLogger"));
+        assert!(output_str.contains("storage IBasicStorage"));
+
+        // Should include the import chain
+        assert!(output_str.contains("NewHostModuleBuilder"));
+    }
+}

--- a/crates/gravity-codegen/src/imports.rs
+++ b/crates/gravity-codegen/src/imports.rs
@@ -1,0 +1,418 @@
+use crate::context::GenerationContext;
+use anyhow::Result;
+use genco::lang::go::Import;
+use genco::prelude::*;
+use gravity_go::Go;
+use heck::ToUpperCamelCase;
+use std::collections::BTreeMap;
+use wit_bindgen_core::wit_parser::{Function, InterfaceId, Resolve, WorldItem, WorldKey};
+
+/// Struct to hold Go import references
+pub struct GoImports {
+    pub context: Import,
+    pub errors: Import,
+    pub wazero_runtime: Import,
+    pub wazero_new_runtime: Import,
+    pub wazero_new_module_config: Import,
+    pub wazero_compiled_module: Import,
+    pub wazero_api_module: Import,
+    pub wazero_api_memory: Import,
+}
+
+impl GoImports {
+    pub fn new() -> Self {
+        Self {
+            context: genco::lang::go::import("context", "Context"),
+            errors: genco::lang::go::import("errors", "New"),
+            wazero_runtime: genco::lang::go::import("github.com/tetratelabs/wazero", "Runtime"),
+            wazero_new_runtime: genco::lang::go::import(
+                "github.com/tetratelabs/wazero",
+                "NewRuntime",
+            ),
+            wazero_new_module_config: genco::lang::go::import(
+                "github.com/tetratelabs/wazero",
+                "NewModuleConfig",
+            ),
+            wazero_compiled_module: genco::lang::go::import(
+                "github.com/tetratelabs/wazero",
+                "CompiledModule",
+            ),
+            wazero_api_module: genco::lang::go::import(
+                "github.com/tetratelabs/wazero/api",
+                "Module",
+            ),
+            wazero_api_memory: genco::lang::go::import(
+                "github.com/tetratelabs/wazero/api",
+                "Memory",
+            ),
+        }
+    }
+}
+
+/// Result of import generation
+pub struct ImportResult {
+    /// Interface names that should be parameters to the factory constructor
+    pub interface_params: Vec<String>,
+    /// Import chains for host module builders (grouped by module name)
+    pub import_chains: BTreeMap<String, Tokens<Go>>,
+}
+
+/// Generator for imports (interfaces, types, functions)
+struct ImportGenerator<'a> {
+    context: &'a mut GenerationContext,
+    resolve: &'a Resolve,
+    world_name: String,
+    go_imports: &'a GoImports,
+    interface_params: Vec<String>,
+    import_chains: BTreeMap<String, Tokens<Go>>,
+}
+
+impl<'a> ImportGenerator<'a> {
+    fn new(
+        context: &'a mut GenerationContext,
+        resolve: &'a Resolve,
+        world_name: &str,
+        go_imports: &'a GoImports,
+    ) -> Self {
+        Self {
+            context,
+            resolve,
+            world_name: world_name.to_string(),
+            go_imports,
+            interface_params: Vec::new(),
+            import_chains: BTreeMap::new(),
+        }
+    }
+
+    /// Main entry point - generates all imports for a world
+    fn generate(
+        &mut self,
+        world_imports: &indexmap::IndexMap<WorldKey, WorldItem>,
+    ) -> Result<ImportResult> {
+        // Process each import
+        for (_import_name, world_item) in world_imports.iter() {
+            match world_item {
+                WorldItem::Interface { id, .. } => {
+                    self.process_interface(*id)?;
+                }
+                WorldItem::Type(type_id) => {
+                    self.process_type(*type_id)?;
+                }
+                WorldItem::Function(_func) => {
+                    // TODO: Handle standalone function imports
+                }
+            }
+        }
+
+        Ok(ImportResult {
+            interface_params: self.interface_params.clone(),
+            import_chains: self.import_chains.clone(),
+        })
+    }
+
+    /// Process an interface import
+    fn process_interface(&mut self, interface_id: InterfaceId) -> Result<()> {
+        let interface = &self.resolve.interfaces[interface_id];
+        let interface_name = interface
+            .name
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("Interface missing name"))?;
+
+        // Add to interface parameters for factory constructor
+        self.interface_params.push(interface_name.clone());
+
+        // Generate interface type definition
+        self.generate_interface_type(interface_id, interface_name)?;
+
+        // Define types used by this interface
+        for type_id in interface.types.values() {
+            self.define_type(*type_id)?;
+        }
+
+        // Generate host module builder
+        self.generate_host_module_builder(interface_id, interface_name)?;
+
+        Ok(())
+    }
+
+    /// Generate the Go interface type definition
+    fn generate_interface_type(
+        &mut self,
+        interface_id: InterfaceId,
+        interface_name: &str,
+    ) -> Result<()> {
+        let interface = &self.resolve.interfaces[interface_id];
+
+        // Generate interface name like IBasicLogger
+        let interface_type_name = format!(
+            "I{}{}",
+            self.world_name.to_upper_camel_case(),
+            interface_name.to_upper_camel_case()
+        );
+
+        // Build method signatures
+        let mut methods = Tokens::new();
+        for func in interface.functions.values() {
+            self.generate_interface_method(func, &mut methods)?;
+        }
+
+        // Generate the interface definition
+        quote_in! { self.context.out =>
+            $['\n']
+            type $(interface_type_name) interface {
+                $methods
+            }
+        };
+
+        Ok(())
+    }
+
+    /// Generate a single method signature for an interface
+    fn generate_interface_method(&self, func: &Function, methods: &mut Tokens<Go>) -> Result<()> {
+        let method_name = func.name.to_upper_camel_case();
+
+        // Build parameters
+        let mut params = vec![quote! { ctx $(self.go_imports.context.clone()) }];
+        for (param_name, param_type) in &func.params {
+            let go_type = crate::resolve_type(param_type, self.resolve)?;
+            params.push(quote! { $param_name $go_type });
+        }
+
+        // Build result type
+        let result = if let Some(result_type) = &func.result {
+            let go_type = crate::resolve_type(result_type, self.resolve)?;
+            quote! { $go_type }
+        } else {
+            quote! {}
+        };
+
+        // Generate method
+        quote_in! { *methods =>
+            $['\r']$(method_name)(
+                $(for param in params join (,$['\r']) => $param),
+            )$(if !result.is_empty() => $[' ']$result)
+        };
+
+        Ok(())
+    }
+
+    /// Generate host module builder for an interface
+    fn generate_host_module_builder(
+        &mut self,
+        interface_id: InterfaceId,
+        interface_name: &str,
+    ) -> Result<()> {
+        let interface = &self.resolve.interfaces[interface_id];
+
+        // Build module name
+        let import_module_name = if let Some(package_id) = interface.package {
+            let package = &self.resolve.packages[package_id];
+            format!(
+                "{}:{}/{}",
+                package.name.namespace, package.name.name, interface_name
+            )
+        } else {
+            interface_name.to_string()
+        };
+
+        // Get or create import chain for this module
+        self.import_chains
+            .entry(import_module_name.clone())
+            .or_insert_with(|| {
+                quote! {
+                    _, err := wazeroRuntime.NewHostModuleBuilder($(quoted(&import_module_name))).
+                }
+            });
+
+        // Generate function builders for each function
+        for func in interface.functions.values() {
+            let mut func_builder = Tokens::<Go>::new();
+            self.generate_function_builder_content(func, interface_name, &mut func_builder)?;
+
+            // Append to import chain
+            if let Some(chain) = self.import_chains.get_mut(&import_module_name) {
+                quote_in! { *chain =>
+                    $func_builder
+                };
+            }
+        }
+
+        // Add instantiate call
+        let import_chain = self.import_chains.get_mut(&import_module_name).unwrap();
+        quote_in! { *import_chain =>
+            $['\r']Instantiate(ctx)
+            $['\r']if err != nil {
+                return nil, err
+            }
+        };
+
+        Ok(())
+    }
+
+    /// Generate a function builder for a host module
+    fn generate_function_builder_content(
+        &self,
+        func: &Function,
+        interface_name: &str,
+        output: &mut Tokens<Go>,
+    ) -> Result<()> {
+        // For now, generate a simple stub
+        // TODO: Use wit_bindgen_core::abi::call to generate proper function body
+
+        let func_name = &func.name;
+        let param_name = interface_name; // This will be the interface parameter name
+
+        // Generate simple string handling for basic cases
+        // This is a simplified version - the real implementation needs wit_bindgen_core::abi::call
+        quote_in! { *output =>
+            $['\r']NewFunctionBuilder().
+            $['\r']WithFunc(func(
+                ctx $(self.go_imports.context.clone()),
+                mod $(self.go_imports.wazero_api_module.clone()),
+                arg0 uint32,
+                arg1 uint32,
+            ) {
+                buf, ok := mod.Memory().Read(arg0, arg1)
+                if !ok {
+                    panic($(self.go_imports.errors.clone())("failed to read bytes from memory"))
+                }
+                str := string(buf)
+                $(param_name).$(func_name.to_upper_camel_case())(ctx, str)
+            }).
+            $['\r']Export($(quoted(func_name))).
+        };
+
+        Ok(())
+    }
+
+    /// Process a standalone type import
+    fn process_type(&mut self, type_id: wit_bindgen_core::wit_parser::TypeId) -> Result<()> {
+        self.define_type(type_id)?;
+        Ok(())
+    }
+
+    /// Define a type in the output
+    fn define_type(&mut self, type_id: wit_bindgen_core::wit_parser::TypeId) -> Result<()> {
+        let type_def = self.resolve.types.get(type_id).unwrap();
+
+        // For now, just generate a comment
+        // TODO: Implement full type generation
+        if let Some(_name) = &type_def.name {
+            quote_in! { self.context.out =>
+                $['\n']
+                // Type: $(name)
+                // TODO: Generate type definition
+            };
+        }
+
+        Ok(())
+    }
+}
+
+/// Generate imports for a WebAssembly component world.
+///
+/// This function generates:
+/// - Go interface definitions for imported interfaces
+/// - Host module builder chains for wazero runtime
+///
+/// Returns an `ImportResult` containing:
+/// - `interface_params`: Names of interfaces that should be parameters to the factory constructor
+/// - `import_chains`: Host module builder code for each imported module
+pub fn generate_imports_with_chains(
+    context: &mut GenerationContext,
+    resolve: &Resolve,
+    world_name: &str,
+    world_imports: &indexmap::IndexMap<WorldKey, WorldItem>,
+    go_imports: &GoImports,
+) -> Result<ImportResult> {
+    let mut generator = ImportGenerator::new(context, resolve, world_name, go_imports);
+    generator.generate(world_imports)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use indexmap::indexmap;
+    use wit_bindgen_core::wit_parser::{
+        Function, FunctionKind, Interface, Package, PackageName, Type, World, WorldId,
+    };
+
+    fn create_test_world_with_interface() -> (Resolve, WorldId) {
+        let mut resolve = Resolve::default();
+
+        // Create a package
+        let package_name = PackageName {
+            namespace: "test".to_string(),
+            name: "pkg".to_string(),
+            version: None,
+        };
+        let package_id = resolve.packages.alloc(Package {
+            name: package_name.clone(),
+            interfaces: Default::default(),
+            worlds: Default::default(),
+            docs: Default::default(),
+        });
+
+        // Create an interface with a function
+        let interface_id = resolve.interfaces.alloc(Interface {
+            name: Some("logger".to_string()),
+            package: Some(package_id),
+            functions: indexmap! {
+                "log".to_string() => Function {
+                    name: "log".to_string(),
+                    params: vec![("message".to_string(), Type::String)],
+                    result: None,
+                    kind: FunctionKind::Freestanding,
+                    docs: Default::default(),
+                    stability: Default::default(),
+                }
+            },
+            types: Default::default(),
+            docs: Default::default(),
+            stability: Default::default(),
+        });
+
+        // Create a world with the interface as import
+        let world = World {
+            name: "test-world".to_string(),
+            imports: indexmap! {
+                WorldKey::Name("logger".to_string()) => WorldItem::Interface { id: interface_id, stability: Default::default() }
+            },
+            exports: Default::default(),
+            docs: Default::default(),
+            stability: Default::default(),
+            package: Some(package_id),
+            includes: Default::default(),
+            include_names: Default::default(),
+        };
+
+        let world_id = resolve.worlds.alloc(world);
+        (resolve, world_id)
+    }
+
+    #[test]
+    fn test_generate_imports_with_interface() {
+        let (resolve, world_id) = create_test_world_with_interface();
+        let world = &resolve.worlds[world_id];
+        let mut context = GenerationContext::new();
+        let go_imports = GoImports::new();
+
+        let result = generate_imports_with_chains(
+            &mut context,
+            &resolve,
+            &world.name,
+            &world.imports,
+            &go_imports,
+        )
+        .unwrap();
+        let interface_params = result.interface_params;
+
+        // Check that we got the interface parameter
+        assert_eq!(interface_params.len(), 1);
+        assert_eq!(interface_params[0], "logger");
+
+        // Check that interface type was generated
+        let output = context.out.to_string().unwrap();
+        assert!(output.contains("type ITestWorldLogger interface"));
+    }
+}

--- a/crates/gravity-codegen/src/instructions/basic.rs
+++ b/crates/gravity-codegen/src/instructions/basic.rs
@@ -2,7 +2,6 @@ use super::InstructionHandler;
 use crate::context::GenerationContext;
 use anyhow::Result;
 use genco::prelude::*;
-use gravity_go::{FormatInto as GravityFormatInto, Go, Tokens};
 use wit_bindgen_core::abi::Instruction;
 use wit_component::DecodedWasm;
 
@@ -177,7 +176,7 @@ impl InstructionHandler for BasicInstructionHandler {
             }
             Instruction::CallWasm { name, .. } => {
                 // Handle function calls
-                let func_name = name.replace('.', "_");
+                let _func_name = name.replace('.', "_");
                 quote_in! { context.body =>
                     $['\r']
                     // Call to $(func_name) - implementation depends on function signature

--- a/crates/gravity-codegen/src/instructions/enum_handler.rs
+++ b/crates/gravity-codegen/src/instructions/enum_handler.rs
@@ -1,0 +1,33 @@
+use super::InstructionHandler;
+use crate::context::GenerationContext;
+use anyhow::Result;
+use wit_bindgen_core::abi::Instruction;
+use wit_bindgen_core::wit_parser::Resolve;
+
+/// Handler for enum-related instructions.
+///
+/// Enums in the component model are simple discriminated unions without payloads,
+/// represented as integers in the ABI.
+pub struct EnumInstructionHandler;
+
+impl InstructionHandler for EnumInstructionHandler {
+    fn can_handle(&self, instruction: &Instruction) -> bool {
+        matches!(
+            instruction,
+            Instruction::EnumLift { .. } | Instruction::EnumLower { .. }
+        )
+    }
+
+    fn handle(
+        &self,
+        _instruction: &Instruction,
+        _context: &mut GenerationContext,
+        _resolve: &Resolve,
+    ) -> Result<()> {
+        // TODO: Implement enum handling
+        // Enums are simpler than variants - they're just integers
+        // EnumLift: Convert from i32 to enum type
+        // EnumLower: Convert from enum type to i32
+        Ok(())
+    }
+}

--- a/crates/gravity-codegen/src/instructions/list.rs
+++ b/crates/gravity-codegen/src/instructions/list.rs
@@ -1,0 +1,26 @@
+use super::InstructionHandler;
+use crate::context::GenerationContext;
+use anyhow::Result;
+use wit_bindgen_core::abi::Instruction;
+use wit_component::DecodedWasm;
+
+pub struct ListInstructionHandler;
+
+impl InstructionHandler for ListInstructionHandler {
+    fn can_handle(&self, instruction: &Instruction) -> bool {
+        matches!(
+            instruction,
+            Instruction::ListLift { .. } | Instruction::ListLower { .. }
+        )
+    }
+
+    fn handle(
+        &self,
+        _instruction: &Instruction,
+        _context: &mut GenerationContext,
+        _decoded: &DecodedWasm,
+    ) -> Result<()> {
+        // TODO: Implement list handling
+        Ok(())
+    }
+}

--- a/crates/gravity-codegen/src/instructions/list.rs
+++ b/crates/gravity-codegen/src/instructions/list.rs
@@ -2,8 +2,12 @@ use super::InstructionHandler;
 use crate::context::GenerationContext;
 use anyhow::Result;
 use wit_bindgen_core::abi::Instruction;
-use wit_component::DecodedWasm;
+use wit_bindgen_core::wit_parser::Resolve;
 
+/// Handler for WebAssembly list instructions.
+///
+/// Processes list-related instructions including lift, lower, canon operations,
+/// and list manipulation.
 pub struct ListInstructionHandler;
 
 impl InstructionHandler for ListInstructionHandler {
@@ -18,7 +22,7 @@ impl InstructionHandler for ListInstructionHandler {
         &self,
         _instruction: &Instruction,
         _context: &mut GenerationContext,
-        _decoded: &DecodedWasm,
+        _resolve: &Resolve,
     ) -> Result<()> {
         // TODO: Implement list handling
         Ok(())

--- a/crates/gravity-codegen/src/instructions/mod.rs
+++ b/crates/gravity-codegen/src/instructions/mod.rs
@@ -8,7 +8,6 @@ pub mod variant;
 
 use crate::context::GenerationContext;
 use anyhow::Result;
-use gravity_go::Operand;
 use wit_bindgen_core::abi::Instruction;
 use wit_component::DecodedWasm;
 

--- a/crates/gravity-codegen/src/instructions/mod.rs
+++ b/crates/gravity-codegen/src/instructions/mod.rs
@@ -1,4 +1,5 @@
 pub mod basic;
+pub mod enum_handler;
 pub mod list;
 pub mod option;
 pub mod record;
@@ -9,24 +10,34 @@ pub mod variant;
 use crate::context::GenerationContext;
 use anyhow::Result;
 use wit_bindgen_core::abi::Instruction;
-use wit_component::DecodedWasm;
+use wit_bindgen_core::wit_parser::Resolve;
 
+/// Trait for handling specific types of WASM component model instructions.
 pub trait InstructionHandler {
+    /// Determines if this handler can process the given instruction.
     fn can_handle(&self, instruction: &Instruction) -> bool;
+
+    /// Processes the instruction, modifying the generation context as needed.
     fn handle(
         &self,
         instruction: &Instruction,
         context: &mut GenerationContext,
-        decoded: &DecodedWasm,
+        resolve: &Resolve,
     ) -> Result<()>;
 }
 
+/// Dispatches an instruction to the appropriate handler.
+///
+/// This function uses a match statement to efficiently route instructions
+/// to their corresponding handlers based on the instruction type.
 pub fn handle_instruction(
     instruction: &Instruction,
     context: &mut GenerationContext,
-    decoded: &DecodedWasm,
+    resolve: &Resolve,
 ) -> Result<()> {
+    // Import handlers only as needed
     use basic::BasicInstructionHandler;
+    use enum_handler::EnumInstructionHandler;
     use list::ListInstructionHandler;
     use option::OptionInstructionHandler;
     use record::RecordInstructionHandler;
@@ -34,21 +45,104 @@ pub fn handle_instruction(
     use string::StringInstructionHandler;
     use variant::VariantInstructionHandler;
 
-    let handlers: Vec<Box<dyn InstructionHandler>> = vec![
-        Box::new(BasicInstructionHandler),
-        Box::new(OptionInstructionHandler),
-        Box::new(RecordInstructionHandler),
-        Box::new(ResultInstructionHandler),
-        Box::new(ListInstructionHandler),
-        Box::new(VariantInstructionHandler),
-        Box::new(StringInstructionHandler),
-    ];
-
-    for handler in handlers {
-        if handler.can_handle(instruction) {
-            return handler.handle(instruction, context, decoded);
+    // Use a match statement for efficient dispatch
+    match instruction {
+        // Basic instructions
+        Instruction::GetArg { .. }
+        | Instruction::I32Const { .. }
+        | Instruction::I32FromBool
+        | Instruction::BoolFromI32
+        | Instruction::I32FromU32
+        | Instruction::U32FromI32
+        | Instruction::I32FromS32
+        | Instruction::S32FromI32
+        | Instruction::I64FromU64
+        | Instruction::U64FromI64
+        | Instruction::I64FromS64
+        | Instruction::S64FromI64
+        | Instruction::I32FromU8
+        | Instruction::U8FromI32
+        | Instruction::I32FromS8
+        | Instruction::S8FromI32
+        | Instruction::I32FromU16
+        | Instruction::U16FromI32
+        | Instruction::I32FromS16
+        | Instruction::S16FromI32
+        | Instruction::I32Load8U { .. }
+        | Instruction::CallWasm { .. }
+        | Instruction::ConstZero { .. } => {
+            BasicInstructionHandler.handle(instruction, context, resolve)
         }
+
+        // Option instructions
+        Instruction::OptionLift { .. } | Instruction::OptionLower { .. } => {
+            OptionInstructionHandler.handle(instruction, context, resolve)
+        }
+
+        // Record instructions
+        Instruction::RecordLift { .. } | Instruction::RecordLower { .. } => {
+            RecordInstructionHandler.handle(instruction, context, resolve)
+        }
+
+        // Result instructions
+        Instruction::ResultLift { .. } | Instruction::ResultLower { .. } => {
+            ResultInstructionHandler.handle(instruction, context, resolve)
+        }
+
+        // List instructions
+        Instruction::ListLift { .. } | Instruction::ListLower { .. } => {
+            ListInstructionHandler.handle(instruction, context, resolve)
+        }
+
+        // Variant instructions
+        Instruction::VariantLift { .. } | Instruction::VariantLower { .. } => {
+            VariantInstructionHandler.handle(instruction, context, resolve)
+        }
+
+        // Enum instructions
+        Instruction::EnumLift { .. } | Instruction::EnumLower { .. } => {
+            EnumInstructionHandler.handle(instruction, context, resolve)
+        }
+
+        // String instructions
+        Instruction::StringLift { .. } | Instruction::StringLower { .. } => {
+            StringInstructionHandler.handle(instruction, context, resolve)
+        }
+
+        // Any other instruction is not yet handled
+        _ => anyhow::bail!("Unhandled instruction: {:?}", instruction),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::context::GenerationContext;
+    use wit_bindgen_core::abi::Instruction;
+
+    #[test]
+    fn test_handle_basic_instruction() {
+        let mut context = GenerationContext::new();
+        let resolve = Resolve::default();
+
+        // Test that basic instructions are handled
+        let instruction = Instruction::GetArg { nth: 0 };
+        let result = handle_instruction(&instruction, &mut context, &resolve);
+        assert!(result.is_ok());
+        assert_eq!(context.operands.len(), 1);
     }
 
-    anyhow::bail!("Unhandled instruction: {:?}", instruction)
+    #[test]
+    fn test_handle_unimplemented_instruction() {
+        let mut context = GenerationContext::new();
+        let resolve = Resolve::default();
+
+        // Test that unimplemented instructions return Ok (they're stubs)
+        let instruction = Instruction::StringLift;
+        let result = handle_instruction(&instruction, &mut context, &resolve);
+        assert!(result.is_ok()); // StringInstructionHandler is a stub that returns Ok(())
+    }
+
+    // TODO: Fix these tests after updating to new Instruction API
+    // The Instruction enum has changed significantly in the latest wit-bindgen-core
 }

--- a/crates/gravity-codegen/src/instructions/mod.rs
+++ b/crates/gravity-codegen/src/instructions/mod.rs
@@ -1,0 +1,55 @@
+pub mod basic;
+pub mod list;
+pub mod option;
+pub mod record;
+pub mod result;
+pub mod string;
+pub mod variant;
+
+use crate::context::GenerationContext;
+use anyhow::Result;
+use gravity_go::Operand;
+use wit_bindgen_core::abi::Instruction;
+use wit_component::DecodedWasm;
+
+pub trait InstructionHandler {
+    fn can_handle(&self, instruction: &Instruction) -> bool;
+    fn handle(
+        &self,
+        instruction: &Instruction,
+        context: &mut GenerationContext,
+        decoded: &DecodedWasm,
+    ) -> Result<()>;
+}
+
+pub fn handle_instruction(
+    instruction: &Instruction,
+    context: &mut GenerationContext,
+    decoded: &DecodedWasm,
+) -> Result<()> {
+    use basic::BasicInstructionHandler;
+    use list::ListInstructionHandler;
+    use option::OptionInstructionHandler;
+    use record::RecordInstructionHandler;
+    use result::ResultInstructionHandler;
+    use string::StringInstructionHandler;
+    use variant::VariantInstructionHandler;
+
+    let handlers: Vec<Box<dyn InstructionHandler>> = vec![
+        Box::new(BasicInstructionHandler),
+        Box::new(OptionInstructionHandler),
+        Box::new(RecordInstructionHandler),
+        Box::new(ResultInstructionHandler),
+        Box::new(ListInstructionHandler),
+        Box::new(VariantInstructionHandler),
+        Box::new(StringInstructionHandler),
+    ];
+
+    for handler in handlers {
+        if handler.can_handle(instruction) {
+            return handler.handle(instruction, context, decoded);
+        }
+    }
+
+    anyhow::bail!("Unhandled instruction: {:?}", instruction)
+}

--- a/crates/gravity-codegen/src/instructions/option.rs
+++ b/crates/gravity-codegen/src/instructions/option.rs
@@ -1,0 +1,26 @@
+use super::InstructionHandler;
+use crate::context::GenerationContext;
+use anyhow::Result;
+use wit_bindgen_core::abi::Instruction;
+use wit_component::DecodedWasm;
+
+pub struct OptionInstructionHandler;
+
+impl InstructionHandler for OptionInstructionHandler {
+    fn can_handle(&self, instruction: &Instruction) -> bool {
+        matches!(
+            instruction,
+            Instruction::OptionLift { .. } | Instruction::OptionLower { .. }
+        )
+    }
+
+    fn handle(
+        &self,
+        _instruction: &Instruction,
+        _context: &mut GenerationContext,
+        _decoded: &DecodedWasm,
+    ) -> Result<()> {
+        // TODO: Implement option handling
+        Ok(())
+    }
+}

--- a/crates/gravity-codegen/src/instructions/option.rs
+++ b/crates/gravity-codegen/src/instructions/option.rs
@@ -2,8 +2,12 @@ use super::InstructionHandler;
 use crate::context::GenerationContext;
 use anyhow::Result;
 use wit_bindgen_core::abi::Instruction;
-use wit_component::DecodedWasm;
+use wit_bindgen_core::wit_parser::Resolve;
 
+/// Handler for WebAssembly option instructions.
+///
+/// Processes option-related instructions including lift, lower,
+/// and Option type conversions.
 pub struct OptionInstructionHandler;
 
 impl InstructionHandler for OptionInstructionHandler {
@@ -18,7 +22,7 @@ impl InstructionHandler for OptionInstructionHandler {
         &self,
         _instruction: &Instruction,
         _context: &mut GenerationContext,
-        _decoded: &DecodedWasm,
+        _resolve: &Resolve,
     ) -> Result<()> {
         // TODO: Implement option handling
         Ok(())

--- a/crates/gravity-codegen/src/instructions/record.rs
+++ b/crates/gravity-codegen/src/instructions/record.rs
@@ -2,8 +2,12 @@ use super::InstructionHandler;
 use crate::context::GenerationContext;
 use anyhow::Result;
 use wit_bindgen_core::abi::Instruction;
-use wit_component::DecodedWasm;
+use wit_bindgen_core::wit_parser::Resolve;
 
+/// Handler for WebAssembly record instructions.
+///
+/// Processes record-related instructions including lift, lower,
+/// and struct/record type operations.
 pub struct RecordInstructionHandler;
 
 impl InstructionHandler for RecordInstructionHandler {
@@ -18,7 +22,7 @@ impl InstructionHandler for RecordInstructionHandler {
         &self,
         _instruction: &Instruction,
         _context: &mut GenerationContext,
-        _decoded: &DecodedWasm,
+        _resolve: &Resolve,
     ) -> Result<()> {
         // TODO: Implement record handling
         Ok(())

--- a/crates/gravity-codegen/src/instructions/record.rs
+++ b/crates/gravity-codegen/src/instructions/record.rs
@@ -1,0 +1,26 @@
+use super::InstructionHandler;
+use crate::context::GenerationContext;
+use anyhow::Result;
+use wit_bindgen_core::abi::Instruction;
+use wit_component::DecodedWasm;
+
+pub struct RecordInstructionHandler;
+
+impl InstructionHandler for RecordInstructionHandler {
+    fn can_handle(&self, instruction: &Instruction) -> bool {
+        matches!(
+            instruction,
+            Instruction::RecordLift { .. } | Instruction::RecordLower { .. }
+        )
+    }
+
+    fn handle(
+        &self,
+        _instruction: &Instruction,
+        _context: &mut GenerationContext,
+        _decoded: &DecodedWasm,
+    ) -> Result<()> {
+        // TODO: Implement record handling
+        Ok(())
+    }
+}

--- a/crates/gravity-codegen/src/instructions/result.rs
+++ b/crates/gravity-codegen/src/instructions/result.rs
@@ -1,0 +1,27 @@
+use super::InstructionHandler;
+use crate::context::GenerationContext;
+use anyhow::Result;
+use wit_bindgen_core::abi::Instruction;
+use wit_component::DecodedWasm;
+
+pub struct ResultInstructionHandler;
+
+impl InstructionHandler for ResultInstructionHandler {
+    fn can_handle(&self, instruction: &Instruction) -> bool {
+        matches!(
+            instruction,
+            Instruction::ResultLift { .. } | Instruction::ResultLower { .. }
+        )
+    }
+
+    fn handle(
+        &self,
+        _instruction: &Instruction,
+        _context: &mut GenerationContext,
+        _decoded: &DecodedWasm,
+    ) -> Result<()> {
+        // TODO: Implement result handling
+        Ok(())
+    }
+}
+EOF </dev/null

--- a/crates/gravity-codegen/src/instructions/result.rs
+++ b/crates/gravity-codegen/src/instructions/result.rs
@@ -2,8 +2,12 @@ use super::InstructionHandler;
 use crate::context::GenerationContext;
 use anyhow::Result;
 use wit_bindgen_core::abi::Instruction;
-use wit_component::DecodedWasm;
+use wit_bindgen_core::wit_parser::Resolve;
 
+/// Handler for WebAssembly result instructions.
+///
+/// Processes result-related instructions including lift, lower,
+/// and Result type conversions for error handling.
 pub struct ResultInstructionHandler;
 
 impl InstructionHandler for ResultInstructionHandler {
@@ -18,7 +22,7 @@ impl InstructionHandler for ResultInstructionHandler {
         &self,
         _instruction: &Instruction,
         _context: &mut GenerationContext,
-        _decoded: &DecodedWasm,
+        _resolve: &Resolve,
     ) -> Result<()> {
         // TODO: Implement result handling
         Ok(())

--- a/crates/gravity-codegen/src/instructions/result.rs
+++ b/crates/gravity-codegen/src/instructions/result.rs
@@ -24,4 +24,3 @@ impl InstructionHandler for ResultInstructionHandler {
         Ok(())
     }
 }
-EOF </dev/null

--- a/crates/gravity-codegen/src/instructions/string.rs
+++ b/crates/gravity-codegen/src/instructions/string.rs
@@ -2,8 +2,12 @@ use super::InstructionHandler;
 use crate::context::GenerationContext;
 use anyhow::Result;
 use wit_bindgen_core::abi::Instruction;
-use wit_component::DecodedWasm;
+use wit_bindgen_core::wit_parser::Resolve;
 
+/// Handler for WebAssembly string instructions.
+///
+/// Processes string-related instructions including lift, lower,
+/// and string encoding operations.
 pub struct StringInstructionHandler;
 
 impl InstructionHandler for StringInstructionHandler {
@@ -18,7 +22,7 @@ impl InstructionHandler for StringInstructionHandler {
         &self,
         _instruction: &Instruction,
         _context: &mut GenerationContext,
-        _decoded: &DecodedWasm,
+        _resolve: &Resolve,
     ) -> Result<()> {
         // TODO: Implement string handling
         Ok(())

--- a/crates/gravity-codegen/src/instructions/string.rs
+++ b/crates/gravity-codegen/src/instructions/string.rs
@@ -1,0 +1,26 @@
+use super::InstructionHandler;
+use crate::context::GenerationContext;
+use anyhow::Result;
+use wit_bindgen_core::abi::Instruction;
+use wit_component::DecodedWasm;
+
+pub struct StringInstructionHandler;
+
+impl InstructionHandler for StringInstructionHandler {
+    fn can_handle(&self, instruction: &Instruction) -> bool {
+        matches!(
+            instruction,
+            Instruction::StringLift { .. } | Instruction::StringLower { .. }
+        )
+    }
+
+    fn handle(
+        &self,
+        _instruction: &Instruction,
+        _context: &mut GenerationContext,
+        _decoded: &DecodedWasm,
+    ) -> Result<()> {
+        // TODO: Implement string handling
+        Ok(())
+    }
+}

--- a/crates/gravity-codegen/src/instructions/variant.rs
+++ b/crates/gravity-codegen/src/instructions/variant.rs
@@ -2,18 +2,19 @@ use super::InstructionHandler;
 use crate::context::GenerationContext;
 use anyhow::Result;
 use wit_bindgen_core::abi::Instruction;
-use wit_component::DecodedWasm;
+use wit_bindgen_core::wit_parser::Resolve;
 
+/// Handler for variant-related instructions.
+///
+/// Variants in the component model are discriminated unions that can have associated data,
+/// similar to Rust enums or tagged unions in other languages.
 pub struct VariantInstructionHandler;
 
 impl InstructionHandler for VariantInstructionHandler {
     fn can_handle(&self, instruction: &Instruction) -> bool {
         matches!(
             instruction,
-            Instruction::VariantLift { .. }
-                | Instruction::VariantLower { .. }
-                | Instruction::EnumLift { .. }
-                | Instruction::EnumLower { .. }
+            Instruction::VariantLift { .. } | Instruction::VariantLower { .. }
         )
     }
 
@@ -21,9 +22,12 @@ impl InstructionHandler for VariantInstructionHandler {
         &self,
         _instruction: &Instruction,
         _context: &mut GenerationContext,
-        _decoded: &DecodedWasm,
+        _resolve: &Resolve,
     ) -> Result<()> {
-        // TODO: Implement variant/enum handling
+        // TODO: Implement variant handling
+        // Variants are more complex than enums - they can have payloads
+        // VariantLift: Convert from ABI representation to high-level variant
+        // VariantLower: Convert from high-level variant to ABI representation
         Ok(())
     }
 }

--- a/crates/gravity-codegen/src/instructions/variant.rs
+++ b/crates/gravity-codegen/src/instructions/variant.rs
@@ -1,0 +1,29 @@
+use super::InstructionHandler;
+use crate::context::GenerationContext;
+use anyhow::Result;
+use wit_bindgen_core::abi::Instruction;
+use wit_component::DecodedWasm;
+
+pub struct VariantInstructionHandler;
+
+impl InstructionHandler for VariantInstructionHandler {
+    fn can_handle(&self, instruction: &Instruction) -> bool {
+        matches!(
+            instruction,
+            Instruction::VariantLift { .. }
+                | Instruction::VariantLower { .. }
+                | Instruction::EnumLift { .. }
+                | Instruction::EnumLower { .. }
+        )
+    }
+
+    fn handle(
+        &self,
+        _instruction: &Instruction,
+        _context: &mut GenerationContext,
+        _decoded: &DecodedWasm,
+    ) -> Result<()> {
+        // TODO: Implement variant/enum handling
+        Ok(())
+    }
+}

--- a/crates/gravity-codegen/src/lib.rs
+++ b/crates/gravity-codegen/src/lib.rs
@@ -1,7 +1,106 @@
 pub mod bindings;
 pub mod context;
+pub mod factory;
+pub mod imports;
 pub mod instructions;
+
+use gravity_go::GoType;
+use wit_bindgen_core::wit_parser::{Resolve, Type, TypeDefKind};
 
 pub use bindings::BindingsGenerator;
 pub use context::GenerationContext;
+pub use factory::{FactoryConfig, FactoryGenerator};
+pub use imports::{generate_imports_with_chains, ImportResult};
 pub use instructions::{handle_instruction, InstructionHandler};
+
+/// Resolves a WIT type to a Go type.
+pub fn resolve_type(typ: &Type, resolve: &Resolve) -> anyhow::Result<GoType> {
+    Ok(match typ {
+        Type::Bool => GoType::Bool,
+        Type::U8 => GoType::Uint8,
+        Type::U16 => GoType::Uint16,
+        Type::U32 => GoType::Uint32,
+        Type::U64 => GoType::Uint64,
+        Type::S8 => GoType::Int8,
+        Type::S16 => GoType::Int16,
+        Type::S32 => GoType::Int32,
+        Type::S64 => GoType::Int64,
+        Type::F32 => GoType::Float32,
+        Type::F64 => GoType::Float64,
+        Type::String => GoType::String,
+        Type::Char => GoType::Uint32, // Char is represented as uint32
+        Type::ErrorContext => GoType::Interface, // TODO: Handle ErrorContext properly
+        Type::Id(id) => {
+            let typedef = resolve.types.get(*id).unwrap();
+            match &typedef.kind {
+                TypeDefKind::List(inner) => GoType::Slice(Box::new(resolve_type(inner, resolve)?)),
+                TypeDefKind::Option(inner) => {
+                    GoType::ValueOrOk(Box::new(resolve_type(inner, resolve)?))
+                }
+                TypeDefKind::Result(result) => match (&result.ok, &result.err) {
+                    (Some(ok), None) => GoType::ValueOrOk(Box::new(resolve_type(ok, resolve)?)),
+                    (None, Some(err)) => {
+                        GoType::ValueOrError(Box::new(resolve_type(err, resolve)?))
+                    }
+                    _ => GoType::Interface, // TODO: Handle other result cases
+                },
+                TypeDefKind::Variant(_) => GoType::Interface,
+                TypeDefKind::Enum(_) => GoType::Uint32, // Enums are represented as integers
+                TypeDefKind::Record(_) | TypeDefKind::Flags(_) | TypeDefKind::Tuple(_) => {
+                    GoType::UserDefined(
+                        typedef
+                            .name
+                            .clone()
+                            .unwrap_or_else(|| "Anonymous".to_string()),
+                    )
+                }
+                TypeDefKind::Type(t) => resolve_type(t, resolve)?,
+                _ => GoType::Interface,
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wit_bindgen_core::wit_parser::{Resolve, Type};
+
+    #[test]
+    fn test_resolve_primitive_types() {
+        let resolve = Resolve::default();
+
+        assert_eq!(resolve_type(&Type::Bool, &resolve).unwrap(), GoType::Bool);
+        assert_eq!(resolve_type(&Type::U8, &resolve).unwrap(), GoType::Uint8);
+        assert_eq!(resolve_type(&Type::U16, &resolve).unwrap(), GoType::Uint16);
+        assert_eq!(resolve_type(&Type::U32, &resolve).unwrap(), GoType::Uint32);
+        assert_eq!(resolve_type(&Type::U64, &resolve).unwrap(), GoType::Uint64);
+        assert_eq!(resolve_type(&Type::S8, &resolve).unwrap(), GoType::Int8);
+        assert_eq!(resolve_type(&Type::S16, &resolve).unwrap(), GoType::Int16);
+        assert_eq!(resolve_type(&Type::S32, &resolve).unwrap(), GoType::Int32);
+        assert_eq!(resolve_type(&Type::S64, &resolve).unwrap(), GoType::Int64);
+        assert_eq!(resolve_type(&Type::F32, &resolve).unwrap(), GoType::Float32);
+        assert_eq!(resolve_type(&Type::F64, &resolve).unwrap(), GoType::Float64);
+        assert_eq!(
+            resolve_type(&Type::String, &resolve).unwrap(),
+            GoType::String
+        );
+    }
+
+    #[test]
+    fn test_resolve_char_type() {
+        let resolve = Resolve::default();
+        // Char is represented as uint32 in Go
+        assert_eq!(resolve_type(&Type::Char, &resolve).unwrap(), GoType::Uint32);
+    }
+
+    #[test]
+    fn test_resolve_error_context_type() {
+        let resolve = Resolve::default();
+        // ErrorContext is represented as interface{} for now
+        assert_eq!(
+            resolve_type(&Type::ErrorContext, &resolve).unwrap(),
+            GoType::Interface
+        );
+    }
+}

--- a/crates/gravity-codegen/src/lib.rs
+++ b/crates/gravity-codegen/src/lib.rs
@@ -1,0 +1,7 @@
+pub mod bindings;
+pub mod context;
+pub mod instructions;
+
+pub use bindings::BindingsGenerator;
+pub use context::GenerationContext;
+pub use instructions::{handle_instruction, InstructionHandler};

--- a/crates/gravity-codegen/src/types.rs
+++ b/crates/gravity-codegen/src/types.rs
@@ -1,0 +1,382 @@
+use anyhow::Result;
+use genco::prelude::*;
+use gravity_go::GoIdentifier;
+use heck::ToUpperCamelCase;
+use wit_bindgen_core::wit_parser::{
+    Enum, Record, Resolve, Type, TypeDef, TypeDefKind, Variant, WorldItem, WorldKey,
+};
+
+use crate::context::GenerationContext;
+use crate::resolve_type;
+
+/// Generator for type definitions
+pub struct TypeGenerator<'a> {
+    context: &'a mut GenerationContext,
+    resolve: &'a Resolve,
+}
+
+impl<'a> TypeGenerator<'a> {
+    pub fn new(context: &'a mut GenerationContext, resolve: &'a Resolve) -> Self {
+        Self { context, resolve }
+    }
+
+    /// Generate all types found in world exports and imports
+    pub fn generate_world_types(
+        mut self,
+        world_exports: &indexmap::IndexMap<WorldKey, WorldItem>,
+        world_imports: &indexmap::IndexMap<WorldKey, WorldItem>,
+    ) -> Result<()> {
+        eprintln!(
+            "DEBUG TypeGenerator::generate_world_types called with {} exports, {} imports",
+            world_exports.len(),
+            world_imports.len()
+        );
+
+        // Collect all type IDs referenced in functions
+        let mut referenced_types = std::collections::HashSet::new();
+
+        // Check exports for type references
+        for (key, item) in world_exports.iter() {
+            eprintln!("DEBUG Processing export for types: {:?}", key);
+            match item {
+                WorldItem::Function(func) => {
+                    // Check parameter types
+                    for (_name, typ) in func.params.iter() {
+                        self.collect_type_references(typ, &mut referenced_types);
+                    }
+                    // Check result type
+                    if let Some(result_typ) = &func.result {
+                        self.collect_type_references(result_typ, &mut referenced_types);
+                    }
+                }
+                WorldItem::Interface { id, .. } => {
+                    // Check interface functions for type references
+                    let interface = &self.resolve.interfaces[*id];
+                    for (_name, func) in interface.functions.iter() {
+                        for (_param_name, typ) in func.params.iter() {
+                            self.collect_type_references(typ, &mut referenced_types);
+                        }
+                        if let Some(result_typ) = &func.result {
+                            self.collect_type_references(result_typ, &mut referenced_types);
+                        }
+                    }
+                }
+                WorldItem::Type(typ_id) => {
+                    referenced_types.insert(*typ_id);
+                }
+            }
+        }
+
+        // Check imports for type references
+        for (key, item) in world_imports.iter() {
+            eprintln!("DEBUG Processing import for types: {:?}", key);
+            match item {
+                WorldItem::Function(func) => {
+                    for (_name, typ) in func.params.iter() {
+                        self.collect_type_references(typ, &mut referenced_types);
+                    }
+                    if let Some(result_typ) = &func.result {
+                        self.collect_type_references(result_typ, &mut referenced_types);
+                    }
+                }
+                WorldItem::Interface { id, .. } => {
+                    let interface = &self.resolve.interfaces[*id];
+                    for (_name, func) in interface.functions.iter() {
+                        for (_param_name, typ) in func.params.iter() {
+                            self.collect_type_references(typ, &mut referenced_types);
+                        }
+                        if let Some(result_typ) = &func.result {
+                            self.collect_type_references(result_typ, &mut referenced_types);
+                        }
+                    }
+                }
+                WorldItem::Type(typ_id) => {
+                    referenced_types.insert(*typ_id);
+                }
+            }
+        }
+
+        eprintln!(
+            "DEBUG Found {} referenced types to generate",
+            referenced_types.len()
+        );
+
+        // Generate types in dependency order
+        let mut generated = std::collections::HashSet::new();
+        for type_id in referenced_types {
+            self.generate_type_recursive(type_id, &mut generated)?;
+        }
+
+        Ok(())
+    }
+
+    /// Recursively collect type IDs referenced by a type
+    fn collect_type_references(
+        &self,
+        typ: &Type,
+        referenced_types: &mut std::collections::HashSet<wit_bindgen_core::wit_parser::TypeId>,
+    ) {
+        match typ {
+            Type::Id(id) => {
+                referenced_types.insert(*id);
+                // Also collect types referenced by this type
+                if let Some(typedef) = self.resolve.types.get(*id) {
+                    self.collect_typedef_references(typedef, referenced_types);
+                }
+            }
+            _ => {
+                // Primitive types don't reference other types
+            }
+        }
+    }
+
+    /// Collect type references from a type definition
+    fn collect_typedef_references(
+        &self,
+        typedef: &TypeDef,
+        referenced_types: &mut std::collections::HashSet<wit_bindgen_core::wit_parser::TypeId>,
+    ) {
+        match &typedef.kind {
+            TypeDefKind::Record(record) => {
+                for field in record.fields.iter() {
+                    self.collect_type_references(&field.ty, referenced_types);
+                }
+            }
+            TypeDefKind::Variant(variant) => {
+                for case in variant.cases.iter() {
+                    if let Some(typ) = &case.ty {
+                        self.collect_type_references(typ, referenced_types);
+                    }
+                }
+            }
+            TypeDefKind::Enum(_) => {
+                // Enums don't reference other types
+            }
+            TypeDefKind::List(inner) => {
+                self.collect_type_references(inner, referenced_types);
+            }
+            TypeDefKind::Option(inner) => {
+                self.collect_type_references(inner, referenced_types);
+            }
+            TypeDefKind::Result(result) => {
+                if let Some(ok) = &result.ok {
+                    self.collect_type_references(ok, referenced_types);
+                }
+                if let Some(err) = &result.err {
+                    self.collect_type_references(err, referenced_types);
+                }
+            }
+            TypeDefKind::Tuple(types) => {
+                for typ in types.types.iter() {
+                    self.collect_type_references(typ, referenced_types);
+                }
+            }
+            TypeDefKind::Type(typ) => {
+                self.collect_type_references(typ, referenced_types);
+            }
+            _ => {
+                // Other kinds don't reference types or are not implemented yet
+            }
+        }
+    }
+
+    /// Generate a type and its dependencies recursively
+    fn generate_type_recursive(
+        &mut self,
+        type_id: wit_bindgen_core::wit_parser::TypeId,
+        generated: &mut std::collections::HashSet<wit_bindgen_core::wit_parser::TypeId>,
+    ) -> Result<()> {
+        if generated.contains(&type_id) {
+            return Ok(()); // Already generated
+        }
+
+        let typedef = self
+            .resolve
+            .types
+            .get(type_id)
+            .ok_or_else(|| anyhow::anyhow!("Type ID {:?} not found in resolve", type_id))?;
+
+        eprintln!(
+            "DEBUG Generating type: {:?} ({})",
+            type_id,
+            typedef.name.as_deref().unwrap_or("anonymous")
+        );
+
+        // Generate dependencies first
+        self.generate_dependencies(typedef, generated)?;
+
+        // Generate this type
+        self.generate_type_definition(typedef)?;
+
+        generated.insert(type_id);
+        Ok(())
+    }
+
+    /// Generate dependencies of a type
+    fn generate_dependencies(
+        &mut self,
+        typedef: &TypeDef,
+        generated: &mut std::collections::HashSet<wit_bindgen_core::wit_parser::TypeId>,
+    ) -> Result<()> {
+        let mut dependencies = std::collections::HashSet::new();
+        self.collect_typedef_references(typedef, &mut dependencies);
+
+        for dep_id in dependencies {
+            if !generated.contains(&dep_id) {
+                self.generate_type_recursive(dep_id, generated)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Generate a single type definition
+    fn generate_type_definition(&mut self, typedef: &TypeDef) -> Result<()> {
+        match &typedef.kind {
+            TypeDefKind::Record(record) => {
+                let name = typedef
+                    .name
+                    .as_deref()
+                    .unwrap_or("Anonymous")
+                    .to_upper_camel_case();
+                self.generate_record_type(record, &name)?;
+            }
+            TypeDefKind::Variant(variant) => {
+                let name = typedef
+                    .name
+                    .as_deref()
+                    .unwrap_or("Anonymous")
+                    .to_upper_camel_case();
+                self.generate_variant_type(variant, &name)?;
+            }
+            TypeDefKind::Enum(enum_) => {
+                let name = typedef
+                    .name
+                    .as_deref()
+                    .unwrap_or("Anonymous")
+                    .to_upper_camel_case();
+                self.generate_enum_type(enum_, &name)?;
+            }
+            TypeDefKind::List(_)
+            | TypeDefKind::Option(_)
+            | TypeDefKind::Result(_)
+            | TypeDefKind::Tuple(_)
+            | TypeDefKind::Type(_) => {
+                // These are handled inline by resolve_type, no separate definition needed
+                eprintln!(
+                    "DEBUG Skipping type definition for inline type: {:?}",
+                    typedef.kind
+                );
+            }
+            _ => {
+                eprintln!("DEBUG Unhandled type definition kind: {:?}", typedef.kind);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Generate a record (struct) type
+    fn generate_record_type(&mut self, record: &Record, name: &str) -> Result<()> {
+        eprintln!("DEBUG Generating record type: {}", name);
+
+        let type_name = GoIdentifier::Public { name };
+
+        // Pre-process field types to handle ValueOrOk -> Pointer conversion for optional fields
+        let field_data: Vec<_> = record
+            .fields
+            .iter()
+            .map(|field| {
+                let field_type = match resolve_type(&field.ty, self.resolve)? {
+                    gravity_go::GoType::ValueOrOk(inner_type) => {
+                        gravity_go::GoType::Pointer(inner_type)
+                    }
+                    other => other,
+                };
+                let field_name = field.name.to_upper_camel_case();
+                Ok((field_name, field_type))
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        quote_in! { self.context.out =>
+            $['\n']
+            type $type_name struct {
+                $(for (field_name, field_type) in field_data.iter() join ($['\r']) =>
+                    $(GoIdentifier::Public { name: field_name }) $field_type)
+            }
+            $['\n']
+        }
+
+        eprintln!("DEBUG Successfully generated record type: {}", name);
+        Ok(())
+    }
+
+    /// Generate a variant (enum-like) type
+    fn generate_variant_type(&mut self, variant: &Variant, name: &str) -> Result<()> {
+        eprintln!("DEBUG Generating variant type: {}", name);
+
+        // Generate the base interface
+        let interface_name = GoIdentifier::Public { name };
+        let discriminant_method = format!("is{}", name);
+
+        quote_in! { self.context.out =>
+            $['\n']
+            type $interface_name interface {
+                $(&discriminant_method)()
+            }
+            $['\n']
+        }
+
+        // Generate case types
+        for case in variant.cases.iter() {
+            let case_name = format!("{}{}", name, case.name.to_upper_camel_case());
+            let case_type = GoIdentifier::Public { name: &case_name };
+            let discriminant_method_ref = &discriminant_method;
+
+            match &case.ty {
+                Some(typ) => {
+                    let go_type = resolve_type(typ, self.resolve)?;
+                    quote_in! { self.context.out =>
+                        type $(&case_type) $go_type
+                        func ($(&case_type)) $(discriminant_method_ref)() {}
+                        $['\n']
+                    }
+                }
+                None => {
+                    // Unit variant - empty struct
+                    quote_in! { self.context.out =>
+                        type $(&case_type) struct {}
+                        func ($(&case_type)) $(discriminant_method_ref)() {}
+                        $['\n']
+                    }
+                }
+            }
+        }
+
+        eprintln!("DEBUG Successfully generated variant type: {}", name);
+        Ok(())
+    }
+
+    /// Generate an enum type
+    fn generate_enum_type(&mut self, enum_: &Enum, name: &str) -> Result<()> {
+        eprintln!("DEBUG Generating enum type: {}", name);
+
+        let type_name = GoIdentifier::Public { name };
+
+        quote_in! { self.context.out =>
+            $['\n']
+            type $(&type_name) uint32
+            $['\n']
+            const (
+                $(for (i, case) in enum_.cases.iter().enumerate() join ($['\r']) =>
+                    $(GoIdentifier::Public {
+                        name: &format!("{}{}", name, case.name.to_upper_camel_case())
+                    }) $(&type_name) = $i)
+            )
+            $['\n']
+        }
+
+        eprintln!("DEBUG Successfully generated enum type: {}", name);
+        Ok(())
+    }
+}

--- a/crates/gravity-go/Cargo.toml
+++ b/crates/gravity-go/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "gravity-go"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+genco = "0.17"
+anyhow = "1.0"
+heck = "0.5"
+
+[dev-dependencies]
+pretty_assertions = "1.4"

--- a/crates/gravity-go/Cargo.toml
+++ b/crates/gravity-go/Cargo.toml
@@ -4,9 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-genco = "0.17"
-anyhow = "1.0"
-heck = "0.5"
+genco = { workspace = true }
+anyhow = { workspace = true }
+heck = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = "1.4"

--- a/crates/gravity-go/src/embed.rs
+++ b/crates/gravity-go/src/embed.rs
@@ -1,0 +1,60 @@
+use genco::lang::Go;
+use genco::tokens::{static_literal, FormatInto, ItemStr, Tokens};
+
+/// Type for generating Go embed directives (//go:embed)
+pub struct Embed<T>(pub T);
+
+impl<T> FormatInto<Go> for Embed<T>
+where
+    T: Into<ItemStr>,
+{
+    fn format_into(self, tokens: &mut Tokens<Go>) {
+        // TODO(#13): Submit patch to genco that will allow aliases for go imports
+        // tokens.register(go::import("embed", ""));
+        tokens.push();
+        tokens.append(static_literal("//go:embed"));
+        tokens.space();
+        tokens.append(self.0.into());
+    }
+}
+
+/// Helper function to create an embed directive
+pub fn embed<T>(path: T) -> Embed<T>
+where
+    T: Into<ItemStr>,
+{
+    Embed(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use genco::prelude::*;
+
+    #[test]
+    fn test_embed_directive() {
+        let mut tokens = Tokens::<Go>::new();
+        let embed = embed("module.wasm");
+
+        quote_in! { tokens =>
+            $(embed)
+        };
+
+        let output = tokens.to_string().unwrap();
+        assert!(output.contains("//go:embed module.wasm"));
+    }
+
+    #[test]
+    fn test_embed_with_variable() {
+        let mut tokens = Tokens::<Go>::new();
+
+        quote_in! { tokens =>
+            $(embed("app.wasm"))
+            var wasmFile []byte
+        };
+
+        let output = tokens.to_string().unwrap();
+        assert!(output.contains("//go:embed app.wasm"));
+        assert!(output.contains("var wasmFile []byte"));
+    }
+}

--- a/crates/gravity-go/src/formatter.rs
+++ b/crates/gravity-go/src/formatter.rs
@@ -4,13 +4,13 @@ use genco::lang::Go;
 use genco::prelude::*;
 use genco::tokens::{static_literal, ItemStr};
 
-impl genco::prelude::FormatInto<Go> for GoType {
+impl FormatInto<Go> for GoType {
     fn format_into(self, tokens: &mut Tokens<Go>) {
         (&self).format_into(tokens)
     }
 }
 
-impl genco::prelude::FormatInto<Go> for &GoType {
+impl FormatInto<Go> for &GoType {
     fn format_into(self, tokens: &mut Tokens<Go>) {
         match self {
             GoType::Bool => tokens.append(static_literal("bool")),
@@ -56,13 +56,13 @@ impl genco::prelude::FormatInto<Go> for &GoType {
     }
 }
 
-impl genco::prelude::FormatInto<Go> for GoResult {
+impl FormatInto<Go> for GoResult {
     fn format_into(self, tokens: &mut Tokens<Go>) {
         (&self).format_into(tokens)
     }
 }
 
-impl genco::prelude::FormatInto<Go> for &GoResult {
+impl FormatInto<Go> for &GoResult {
     fn format_into(self, tokens: &mut Tokens<Go>) {
         match &self {
             GoResult::Anon(typ @ GoType::ValueOrError(_) | typ @ GoType::ValueOrOk(_)) => {
@@ -76,7 +76,7 @@ impl genco::prelude::FormatInto<Go> for &GoResult {
 }
 
 // Implement genco's FormatInto for Operand so it can be used in quote! macros
-impl genco::prelude::FormatInto<Go> for &Operand {
+impl FormatInto<Go> for &Operand {
     fn format_into(self, tokens: &mut Tokens<Go>) {
         match self {
             Operand::Literal(val) => tokens.append(ItemStr::from(val)),
@@ -91,13 +91,13 @@ impl genco::prelude::FormatInto<Go> for &Operand {
     }
 }
 
-impl genco::prelude::FormatInto<Go> for Operand {
+impl FormatInto<Go> for Operand {
     fn format_into(self, tokens: &mut Tokens<Go>) {
         (&self).format_into(tokens)
     }
 }
 
-impl genco::prelude::FormatInto<Go> for &mut Operand {
+impl FormatInto<Go> for &mut Operand {
     fn format_into(self, tokens: &mut Tokens<Go>) {
         let op: &Operand = self;
         op.format_into(tokens)

--- a/crates/gravity-go/src/formatter.rs
+++ b/crates/gravity-go/src/formatter.rs
@@ -1,23 +1,9 @@
 use crate::identifier::GoIdentifier;
 use crate::types::{GoResult, GoType, Operand};
-use genco::lang::{Go, Lang};
+use genco::lang::Go;
 use genco::prelude::*;
 use genco::tokens::{static_literal, ItemStr};
 
-/// Trait for formatting types into language-specific tokens.
-///
-/// This trait allows types to be formatted into token streams
-/// for code generation. It's primarily used for Go code generation
-/// but is generic over the language type.
-pub trait FormatInto<L: Lang> {
-    /// Formats the type into the provided token stream.
-    ///
-    /// # Arguments
-    /// * `tokens` - The token stream to append formatted output to.
-    fn format_into(self, tokens: &mut Tokens<L>);
-}
-
-// Implement only genco's FormatInto trait (not our own) to avoid conflicts
 impl genco::prelude::FormatInto<Go> for GoType {
     fn format_into(self, tokens: &mut Tokens<Go>) {
         (&self).format_into(tokens)

--- a/crates/gravity-go/src/formatter.rs
+++ b/crates/gravity-go/src/formatter.rs
@@ -1,74 +1,90 @@
+use crate::identifier::GoIdentifier;
 use crate::types::{GoResult, GoType, Operand};
 use genco::lang::{Go, Lang};
 use genco::prelude::*;
-use genco::tokens::ItemStr;
+use genco::tokens::{static_literal, ItemStr};
 
+/// Trait for formatting types into language-specific tokens.
+///
+/// This trait allows types to be formatted into token streams
+/// for code generation. It's primarily used for Go code generation
+/// but is generic over the language type.
 pub trait FormatInto<L: Lang> {
+    /// Formats the type into the provided token stream.
+    ///
+    /// # Arguments
+    /// * `tokens` - The token stream to append formatted output to.
     fn format_into(self, tokens: &mut Tokens<L>);
 }
 
-impl FormatInto<Go> for GoType {
+// Implement only genco's FormatInto trait (not our own) to avoid conflicts
+impl genco::prelude::FormatInto<Go> for GoType {
     fn format_into(self, tokens: &mut Tokens<Go>) {
         (&self).format_into(tokens)
     }
 }
 
-impl FormatInto<Go> for &GoType {
+impl genco::prelude::FormatInto<Go> for &GoType {
     fn format_into(self, tokens: &mut Tokens<Go>) {
         match self {
-            GoType::Bool => tokens.append("bool"),
-            GoType::Uint8 => tokens.append("uint8"),
-            GoType::Uint16 => tokens.append("uint16"),
-            GoType::Uint32 => tokens.append("uint32"),
-            GoType::Uint64 => tokens.append("uint64"),
-            GoType::Int8 => tokens.append("int8"),
-            GoType::Int16 => tokens.append("int16"),
-            GoType::Int32 => tokens.append("int32"),
-            GoType::Int64 => tokens.append("int64"),
-            GoType::Float32 => tokens.append("float32"),
-            GoType::Float64 => tokens.append("float64"),
-            GoType::String => tokens.append("string"),
-            GoType::Error => tokens.append("error"),
-            GoType::Interface => tokens.append("interface{}"),
-            GoType::Pointer(inner) => {
-                tokens.append("*");
-                inner.as_ref().format_into(tokens);
+            GoType::Bool => tokens.append(static_literal("bool")),
+            GoType::Uint8 => tokens.append(static_literal("uint8")),
+            GoType::Uint16 => tokens.append(static_literal("uint16")),
+            GoType::Uint32 => tokens.append(static_literal("uint32")),
+            GoType::Uint64 => tokens.append(static_literal("uint64")),
+            GoType::Int8 => tokens.append(static_literal("int8")),
+            GoType::Int16 => tokens.append(static_literal("int16")),
+            GoType::Int32 => tokens.append(static_literal("int32")),
+            GoType::Int64 => tokens.append(static_literal("int64")),
+            GoType::Float32 => tokens.append(static_literal("float32")),
+            GoType::Float64 => tokens.append(static_literal("float64")),
+            GoType::String => tokens.append(static_literal("string")),
+            GoType::Error => tokens.append(static_literal("error")),
+            GoType::Interface => tokens.append(static_literal("interface{}")),
+            GoType::ValueOrOk(value_typ) => {
+                value_typ.as_ref().format_into(tokens);
+                tokens.append(static_literal(","));
+                tokens.space();
+                tokens.append(static_literal("bool"))
             }
-            GoType::ValueOrOk(inner) => {
-                tokens.append("(");
-                inner.as_ref().format_into(tokens);
-                tokens.append(", bool)");
+            GoType::ValueOrError(value_typ) => {
+                value_typ.as_ref().format_into(tokens);
+                tokens.append(static_literal(","));
+                tokens.space();
+                tokens.append(static_literal("error"))
             }
-            GoType::ValueOrError(inner) => {
-                tokens.append("(");
-                inner.as_ref().format_into(tokens);
-                tokens.append(", error)");
+            GoType::Slice(typ) => {
+                tokens.append(static_literal("[]"));
+                typ.as_ref().format_into(tokens);
             }
-            GoType::Slice(inner) => {
-                tokens.append("[]");
-                inner.as_ref().format_into(tokens);
+            GoType::Pointer(typ) => {
+                tokens.append(static_literal("*"));
+                typ.as_ref().format_into(tokens);
             }
-            GoType::UserDefined(name) => tokens.append(name.as_str()),
-            GoType::Nothing => {}
+            GoType::UserDefined(name) => {
+                let id = GoIdentifier::Public { name };
+                id.format_into(tokens)
+            }
+            GoType::Nothing => (),
         }
     }
 }
 
-impl FormatInto<Go> for GoResult {
+impl genco::prelude::FormatInto<Go> for GoResult {
     fn format_into(self, tokens: &mut Tokens<Go>) {
         (&self).format_into(tokens)
     }
 }
 
-impl FormatInto<Go> for &GoResult {
+impl genco::prelude::FormatInto<Go> for &GoResult {
     fn format_into(self, tokens: &mut Tokens<Go>) {
-        match self {
-            GoResult::Empty => tokens.append("error"),
-            GoResult::Anon(typ) => {
-                tokens.append("(");
-                typ.format_into(tokens);
-                tokens.append(", error)");
+        match &self {
+            GoResult::Anon(typ @ GoType::ValueOrError(_) | typ @ GoType::ValueOrOk(_)) => {
+                // Be cautious here as there are `(` and `)` surrounding the type
+                tokens.append(quote!(($typ)))
             }
+            GoResult::Anon(typ) => typ.format_into(tokens),
+            GoResult::Empty => (),
         }
     }
 }
@@ -81,7 +97,7 @@ impl genco::prelude::FormatInto<Go> for &Operand {
             Operand::SingleValue(val) => tokens.append(ItemStr::from(val)),
             Operand::MultiValue((val1, val2)) => {
                 tokens.append(ItemStr::from(val1));
-                tokens.append(",");
+                tokens.append(static_literal(","));
                 tokens.space();
                 tokens.append(ItemStr::from(val2));
             }
@@ -99,5 +115,159 @@ impl genco::prelude::FormatInto<Go> for &mut Operand {
     fn format_into(self, tokens: &mut Tokens<Go>) {
         let op: &Operand = self;
         op.format_into(tokens)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{GoResult, GoType, Operand};
+    use genco::prelude::FormatInto;
+
+    #[test]
+    fn test_basic_types() {
+        let cases = vec![
+            (GoType::Bool, "bool"),
+            (GoType::Uint8, "uint8"),
+            (GoType::Uint16, "uint16"),
+            (GoType::Uint32, "uint32"),
+            (GoType::Uint64, "uint64"),
+            (GoType::Int8, "int8"),
+            (GoType::Int16, "int16"),
+            (GoType::Int32, "int32"),
+            (GoType::Int64, "int64"),
+            (GoType::Float32, "float32"),
+            (GoType::Float64, "float64"),
+            (GoType::String, "string"),
+            (GoType::Error, "error"),
+            (GoType::Interface, "interface{}"),
+            (GoType::Nothing, ""),
+        ];
+
+        for (typ, expected) in cases {
+            let mut tokens = Tokens::<Go>::new();
+            (&typ).format_into(&mut tokens);
+            assert_eq!(
+                tokens.to_string().unwrap(),
+                expected,
+                "Failed for type: {:?}",
+                typ
+            );
+        }
+    }
+
+    #[test]
+    fn test_value_or_ok() {
+        let typ = GoType::ValueOrOk(Box::new(GoType::Uint32));
+        let mut tokens = Tokens::<Go>::new();
+        (&typ).format_into(&mut tokens);
+        assert_eq!(tokens.to_string().unwrap(), "uint32, bool");
+    }
+
+    #[test]
+    fn test_value_or_error() {
+        let typ = GoType::ValueOrError(Box::new(GoType::String));
+        let mut tokens = Tokens::<Go>::new();
+        (&typ).format_into(&mut tokens);
+        assert_eq!(tokens.to_string().unwrap(), "string, error");
+    }
+
+    #[test]
+    fn test_slice() {
+        let typ = GoType::Slice(Box::new(GoType::Int32));
+        let mut tokens = Tokens::<Go>::new();
+        (&typ).format_into(&mut tokens);
+        assert_eq!(tokens.to_string().unwrap(), "[]int32");
+    }
+
+    #[test]
+    fn test_pointer() {
+        let typ = GoType::Pointer(Box::new(GoType::String));
+        let mut tokens = Tokens::<Go>::new();
+        (&typ).format_into(&mut tokens);
+        assert_eq!(tokens.to_string().unwrap(), "*string");
+    }
+
+    #[test]
+    fn test_nested_types() {
+        // Test *[]string
+        let typ = GoType::Pointer(Box::new(GoType::Slice(Box::new(GoType::String))));
+        let mut tokens = Tokens::<Go>::new();
+        (&typ).format_into(&mut tokens);
+        assert_eq!(tokens.to_string().unwrap(), "*[]string");
+
+        // Test [][]uint8
+        let typ = GoType::Slice(Box::new(GoType::Slice(Box::new(GoType::Uint8))));
+        let mut tokens = Tokens::<Go>::new();
+        (&typ).format_into(&mut tokens);
+        assert_eq!(tokens.to_string().unwrap(), "[][]uint8");
+    }
+
+    #[test]
+    fn test_go_result_empty() {
+        let result = GoResult::Empty;
+        let mut tokens = Tokens::<Go>::new();
+        (&result).format_into(&mut tokens);
+        assert_eq!(tokens.to_string().unwrap(), "");
+    }
+
+    #[test]
+    fn test_go_result_simple_type() {
+        let result = GoResult::Anon(GoType::String);
+        let mut tokens = Tokens::<Go>::new();
+        (&result).format_into(&mut tokens);
+        assert_eq!(tokens.to_string().unwrap(), "string");
+    }
+
+    #[test]
+    fn test_go_result_value_or_ok() {
+        // GoResult with ValueOrOk should add parentheses
+        let result = GoResult::Anon(GoType::ValueOrOk(Box::new(GoType::Uint32)));
+        let mut tokens = Tokens::<Go>::new();
+        (&result).format_into(&mut tokens);
+        assert_eq!(tokens.to_string().unwrap(), "(uint32, bool)");
+    }
+
+    #[test]
+    fn test_go_result_value_or_error() {
+        // GoResult with ValueOrError should add parentheses
+        let result = GoResult::Anon(GoType::ValueOrError(Box::new(GoType::String)));
+        let mut tokens = Tokens::<Go>::new();
+        (&result).format_into(&mut tokens);
+        assert_eq!(tokens.to_string().unwrap(), "(string, error)");
+    }
+
+    #[test]
+    fn test_operand_literal() {
+        let op = Operand::Literal("42".to_string());
+        let mut tokens = Tokens::<Go>::new();
+        op.format_into(&mut tokens);
+        assert_eq!(tokens.to_string().unwrap(), "42");
+    }
+
+    #[test]
+    fn test_operand_single_value() {
+        let op = Operand::SingleValue("myVar".to_string());
+        let mut tokens = Tokens::<Go>::new();
+        op.format_into(&mut tokens);
+        assert_eq!(tokens.to_string().unwrap(), "myVar");
+    }
+
+    #[test]
+    fn test_operand_multi_value() {
+        let op = Operand::MultiValue(("val1".to_string(), "val2".to_string()));
+        let mut tokens = Tokens::<Go>::new();
+        op.format_into(&mut tokens);
+        assert_eq!(tokens.to_string().unwrap(), "val1, val2");
+    }
+
+    #[test]
+    fn test_user_defined_type() {
+        // User-defined types should be formatted with proper casing
+        let typ = GoType::UserDefined("myCustomType".to_string());
+        let mut tokens = Tokens::<Go>::new();
+        (&typ).format_into(&mut tokens);
+        // This should use GoIdentifier formatting which capitalizes the first letter
+        assert_eq!(tokens.to_string().unwrap(), "MyCustomType");
     }
 }

--- a/crates/gravity-go/src/formatter.rs
+++ b/crates/gravity-go/src/formatter.rs
@@ -1,0 +1,94 @@
+use crate::types::{GoResult, GoType, Operand};
+use genco::lang::{Go, Lang};
+use genco::prelude::*;
+
+pub trait FormatInto<L: Lang> {
+    fn format_into(self, tokens: &mut Tokens<L>);
+}
+
+impl FormatInto<Go> for GoType {
+    fn format_into(self, tokens: &mut Tokens<Go>) {
+        (&self).format_into(tokens)
+    }
+}
+
+impl FormatInto<Go> for &GoType {
+    fn format_into(self, tokens: &mut Tokens<Go>) {
+        match self {
+            GoType::Bool => tokens.append("bool"),
+            GoType::Uint8 => tokens.append("uint8"),
+            GoType::Uint16 => tokens.append("uint16"),
+            GoType::Uint32 => tokens.append("uint32"),
+            GoType::Uint64 => tokens.append("uint64"),
+            GoType::Int8 => tokens.append("int8"),
+            GoType::Int16 => tokens.append("int16"),
+            GoType::Int32 => tokens.append("int32"),
+            GoType::Int64 => tokens.append("int64"),
+            GoType::Float32 => tokens.append("float32"),
+            GoType::Float64 => tokens.append("float64"),
+            GoType::String => tokens.append("string"),
+            GoType::Error => tokens.append("error"),
+            GoType::Interface => tokens.append("interface{}"),
+            GoType::Pointer(inner) => {
+                tokens.append("*");
+                inner.as_ref().format_into(tokens);
+            }
+            GoType::ValueOrOk(inner) => {
+                tokens.append("(");
+                inner.as_ref().format_into(tokens);
+                tokens.append(", bool)");
+            }
+            GoType::ValueOrError(inner) => {
+                tokens.append("(");
+                inner.as_ref().format_into(tokens);
+                tokens.append(", error)");
+            }
+            GoType::Slice(inner) => {
+                tokens.append("[]");
+                inner.as_ref().format_into(tokens);
+            }
+            GoType::UserDefined(name) => tokens.append(name.as_str()),
+            GoType::Nothing => {}
+        }
+    }
+}
+
+impl FormatInto<Go> for GoResult {
+    fn format_into(self, tokens: &mut Tokens<Go>) {
+        (&self).format_into(tokens)
+    }
+}
+
+impl FormatInto<Go> for &GoResult {
+    fn format_into(self, tokens: &mut Tokens<Go>) {
+        match self {
+            GoResult::Empty => tokens.append("error"),
+            GoResult::Anon(typ) => {
+                tokens.append("(");
+                typ.format_into(tokens);
+                tokens.append(", error)");
+            }
+        }
+    }
+}
+
+impl FormatInto<Go> for &Operand {
+    fn format_into(self, tokens: &mut Tokens<Go>) {
+        match self {
+            Operand::Literal(val) => tokens.append(val.as_str()),
+            Operand::SingleValue(val) => tokens.append(val.as_str()),
+            Operand::MultiValue((val1, val2)) => {
+                tokens.append(val1.as_str());
+                tokens.append(",");
+                tokens.space();
+                tokens.append(val2.as_str());
+            }
+        }
+    }
+}
+
+impl FormatInto<Go> for Operand {
+    fn format_into(self, tokens: &mut Tokens<Go>) {
+        (&self).format_into(tokens)
+    }
+}

--- a/crates/gravity-go/src/formatter.rs
+++ b/crates/gravity-go/src/formatter.rs
@@ -1,6 +1,7 @@
 use crate::types::{GoResult, GoType, Operand};
 use genco::lang::{Go, Lang};
 use genco::prelude::*;
+use genco::tokens::ItemStr;
 
 pub trait FormatInto<L: Lang> {
     fn format_into(self, tokens: &mut Tokens<L>);
@@ -72,23 +73,31 @@ impl FormatInto<Go> for &GoResult {
     }
 }
 
-impl FormatInto<Go> for &Operand {
+// Implement genco's FormatInto for Operand so it can be used in quote! macros
+impl genco::prelude::FormatInto<Go> for &Operand {
     fn format_into(self, tokens: &mut Tokens<Go>) {
         match self {
-            Operand::Literal(val) => tokens.append(val.as_str()),
-            Operand::SingleValue(val) => tokens.append(val.as_str()),
+            Operand::Literal(val) => tokens.append(ItemStr::from(val)),
+            Operand::SingleValue(val) => tokens.append(ItemStr::from(val)),
             Operand::MultiValue((val1, val2)) => {
-                tokens.append(val1.as_str());
+                tokens.append(ItemStr::from(val1));
                 tokens.append(",");
                 tokens.space();
-                tokens.append(val2.as_str());
+                tokens.append(ItemStr::from(val2));
             }
         }
     }
 }
 
-impl FormatInto<Go> for Operand {
+impl genco::prelude::FormatInto<Go> for Operand {
     fn format_into(self, tokens: &mut Tokens<Go>) {
         (&self).format_into(tokens)
+    }
+}
+
+impl genco::prelude::FormatInto<Go> for &mut Operand {
+    fn format_into(self, tokens: &mut Tokens<Go>) {
+        let op: &Operand = self;
+        op.format_into(tokens)
     }
 }

--- a/crates/gravity-go/src/identifier.rs
+++ b/crates/gravity-go/src/identifier.rs
@@ -29,7 +29,7 @@ impl From<GoIdentifier<'_>> for String {
     }
 }
 
-impl<'a> FormatInto<Go> for GoIdentifier<'a> {
+impl FormatInto<Go> for GoIdentifier<'_> {
     fn format_into(self, tokens: &mut Tokens<Go>) {
         match self {
             GoIdentifier::Public { name } => {

--- a/crates/gravity-go/src/identifier.rs
+++ b/crates/gravity-go/src/identifier.rs
@@ -4,14 +4,29 @@ use genco::prelude::*;
 use heck::{ToLowerCamelCase, ToUpperCamelCase};
 use std::str::Chars;
 
+/// Represents a Go identifier with appropriate casing rules.
+///
+/// Go identifiers follow specific naming conventions:
+/// - Public identifiers start with uppercase (exported)
+/// - Private identifiers start with lowercase (unexported)
+/// - Local identifiers are used as-is without transformation
 #[derive(Debug, Clone)]
 pub enum GoIdentifier<'a> {
+    /// Public/exported identifier (will be converted to UpperCamelCase)
     Public { name: &'a str },
+    /// Private/unexported identifier (will be converted to lowerCamelCase)
     Private { name: &'a str },
+    /// Local identifier (used as-is without case transformation)
     Local { name: &'a str },
 }
 
 impl<'a> GoIdentifier<'a> {
+    /// Returns an iterator over the characters of the underlying name.
+    ///
+    /// This provides access to the raw name without case transformations.
+    ///
+    /// # Returns
+    /// An iterator over the characters of the identifier's name.
     pub fn chars(&self) -> Chars<'a> {
         match self {
             GoIdentifier::Public { name } => name.chars(),

--- a/crates/gravity-go/src/identifier.rs
+++ b/crates/gravity-go/src/identifier.rs
@@ -1,4 +1,3 @@
-use crate::formatter::FormatInto;
 use genco::lang::Go;
 use genco::prelude::*;
 use heck::{ToLowerCamelCase, ToUpperCamelCase};
@@ -36,15 +35,15 @@ impl<'a> GoIdentifier<'a> {
     }
 }
 
-impl From<GoIdentifier<'_>> for String {
-    fn from(value: GoIdentifier) -> Self {
-        let mut tokens: Tokens<Go> = Tokens::new();
-        value.format_into(&mut tokens);
-        tokens.to_string().expect("to format correctly")
-    }
-}
+// impl From<GoIdentifier<'_>> for String {
+//     fn from(value: GoIdentifier) -> Self {
+//         let mut tokens: Tokens<Go> = Tokens::new();
+//         value.format_into(&mut tokens);
+//         tokens.to_string().expect("to format correctly")
+//     }
+// }
 
-impl FormatInto<Go> for GoIdentifier<'_> {
+impl FormatInto<Go> for &GoIdentifier<'_> {
     fn format_into(self, tokens: &mut Tokens<Go>) {
         match self {
             GoIdentifier::Public { name } => {
@@ -56,8 +55,14 @@ impl FormatInto<Go> for GoIdentifier<'_> {
                 tokens.append(formatted);
             }
             GoIdentifier::Local { name } => {
-                tokens.append(name);
+                tokens.append(*name);
             }
         }
+    }
+}
+
+impl FormatInto<Go> for GoIdentifier<'_> {
+    fn format_into(self, tokens: &mut Tokens<Go>) {
+        (&self).format_into(tokens)
     }
 }

--- a/crates/gravity-go/src/identifier.rs
+++ b/crates/gravity-go/src/identifier.rs
@@ -1,0 +1,48 @@
+use crate::formatter::FormatInto;
+use genco::lang::Go;
+use genco::prelude::*;
+use heck::{ToLowerCamelCase, ToUpperCamelCase};
+use std::str::Chars;
+
+#[derive(Debug, Clone)]
+pub enum GoIdentifier<'a> {
+    Public { name: &'a str },
+    Private { name: &'a str },
+    Local { name: &'a str },
+}
+
+impl<'a> GoIdentifier<'a> {
+    pub fn chars(&self) -> Chars<'a> {
+        match self {
+            GoIdentifier::Public { name } => name.chars(),
+            GoIdentifier::Private { name } => name.chars(),
+            GoIdentifier::Local { name } => name.chars(),
+        }
+    }
+}
+
+impl From<GoIdentifier<'_>> for String {
+    fn from(value: GoIdentifier) -> Self {
+        let mut tokens: Tokens<Go> = Tokens::new();
+        value.format_into(&mut tokens);
+        tokens.to_string().expect("to format correctly")
+    }
+}
+
+impl<'a> FormatInto<Go> for GoIdentifier<'a> {
+    fn format_into(self, tokens: &mut Tokens<Go>) {
+        match self {
+            GoIdentifier::Public { name } => {
+                let formatted = name.to_upper_camel_case();
+                tokens.append(formatted);
+            }
+            GoIdentifier::Private { name } => {
+                let formatted = name.to_lower_camel_case();
+                tokens.append(formatted);
+            }
+            GoIdentifier::Local { name } => {
+                tokens.append(name);
+            }
+        }
+    }
+}

--- a/crates/gravity-go/src/identifier.rs
+++ b/crates/gravity-go/src/identifier.rs
@@ -35,14 +35,6 @@ impl<'a> GoIdentifier<'a> {
     }
 }
 
-// impl From<GoIdentifier<'_>> for String {
-//     fn from(value: GoIdentifier) -> Self {
-//         let mut tokens: Tokens<Go> = Tokens::new();
-//         value.format_into(&mut tokens);
-//         tokens.to_string().expect("to format correctly")
-//     }
-// }
-
 impl FormatInto<Go> for &GoIdentifier<'_> {
     fn format_into(self, tokens: &mut Tokens<Go>) {
         match self {

--- a/crates/gravity-go/src/lib.rs
+++ b/crates/gravity-go/src/lib.rs
@@ -1,8 +1,9 @@
+pub mod embed;
 pub mod formatter;
 pub mod identifier;
 pub mod types;
 
-pub use formatter::FormatInto;
+pub use embed::{embed, Embed};
 pub use identifier::GoIdentifier;
 pub use types::{GoResult, GoType, Operand};
 

--- a/crates/gravity-go/src/lib.rs
+++ b/crates/gravity-go/src/lib.rs
@@ -1,0 +1,10 @@
+pub mod formatter;
+pub mod identifier;
+pub mod types;
+
+pub use formatter::FormatInto;
+pub use identifier::GoIdentifier;
+pub use types::{GoResult, GoType, Operand};
+
+// Re-export genco types that are commonly used
+pub use genco::{lang::Go, quote, Tokens};

--- a/crates/gravity-go/src/types.rs
+++ b/crates/gravity-go/src/types.rs
@@ -1,0 +1,102 @@
+#[derive(Debug, Clone, PartialEq)]
+pub enum GoType {
+    Bool,
+    Uint8,
+    Uint16,
+    Uint32,
+    Uint64,
+    Int8,
+    Int16,
+    Int32,
+    Int64,
+    Float32,
+    Float64,
+    String,
+    Error,
+    Interface,
+    Pointer(Box<GoType>),
+    ValueOrOk(Box<GoType>),
+    ValueOrError(Box<GoType>),
+    Slice(Box<GoType>),
+    UserDefined(String),
+    Nothing,
+}
+
+impl GoType {
+    /// Returns true if this type needs post-return cleanup (cabi_post_* function)
+    ///
+    /// According to the Component Model Canonical ABI specification, cleanup is needed
+    /// for types that allocate memory in the guest's linear memory when being returned.
+    ///
+    /// Types that need cleanup:
+    /// - Strings (allocate memory for the string data)
+    /// - Lists/Slices (allocate memory for the list elements)
+    /// - Records with fields that need cleanup
+    /// - Variants with cases that need cleanup
+    /// - Results with values that need cleanup
+    ///
+    /// Types that don't need cleanup:
+    /// - Primitive numeric types (passed by value)
+    /// - Booleans (passed by value)
+    /// - Empty results
+    pub fn needs_cleanup(&self) -> bool {
+        match self {
+            // Primitive types don't need cleanup
+            GoType::Bool
+            | GoType::Uint8
+            | GoType::Uint16
+            | GoType::Uint32
+            | GoType::Uint64
+            | GoType::Int8
+            | GoType::Int16
+            | GoType::Int32
+            | GoType::Int64
+            | GoType::Float32
+            | GoType::Float64
+            | GoType::Interface
+            | GoType::Nothing => false,
+
+            // String always needs cleanup
+            GoType::String => true,
+
+            // Lists always need cleanup
+            GoType::Slice(_) => true,
+
+            // Pointers need cleanup if the inner type does
+            GoType::Pointer(inner) => inner.needs_cleanup(),
+
+            // ValueOrOk and ValueOrError need cleanup if the inner type does
+            GoType::ValueOrOk(inner) | GoType::ValueOrError(inner) => inner.needs_cleanup(),
+
+            // Error types typically need cleanup (they contain strings)
+            GoType::Error => true,
+
+            // User-defined types might need cleanup (conservatively return true)
+            // In practice, we'd need to look up the actual type definition
+            GoType::UserDefined(_) => true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum GoResult {
+    Empty,
+    Anon(GoType),
+}
+
+impl GoResult {
+    /// Returns true if this result type needs post-return cleanup
+    pub fn needs_cleanup(&self) -> bool {
+        match self {
+            GoResult::Empty => false,
+            GoResult::Anon(typ) => typ.needs_cleanup(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Operand {
+    Literal(String),
+    SingleValue(String),
+    MultiValue((String, String)),
+}

--- a/crates/gravity-go/src/types.rs
+++ b/crates/gravity-go/src/types.rs
@@ -100,3 +100,15 @@ pub enum Operand {
     SingleValue(String),
     MultiValue((String, String)),
 }
+
+impl Operand {
+    /// Returns the primary value of the operand (for single values and literals)
+    /// or the first value of a multi-value tuple
+    pub fn as_string(&self) -> String {
+        match self {
+            Operand::Literal(s) => s.clone(),
+            Operand::SingleValue(s) => s.clone(),
+            Operand::MultiValue((s1, _)) => s1.clone(),
+        }
+    }
+}

--- a/crates/gravity-go/src/types.rs
+++ b/crates/gravity-go/src/types.rs
@@ -1,24 +1,48 @@
+/// Represents a Go type in the code generation system.
+///
+/// This enum covers all the basic Go types as well as special types
+/// used for WebAssembly Component Model interop.
 #[derive(Debug, Clone, PartialEq)]
 pub enum GoType {
+    /// Boolean type
     Bool,
+    /// Unsigned 8-bit integer
     Uint8,
+    /// Unsigned 16-bit integer
     Uint16,
+    /// Unsigned 32-bit integer
     Uint32,
+    /// Unsigned 64-bit integer
     Uint64,
+    /// Signed 8-bit integer
     Int8,
+    /// Signed 16-bit integer
     Int16,
+    /// Signed 32-bit integer
     Int32,
+    /// Signed 64-bit integer
     Int64,
+    /// 32-bit floating point
     Float32,
+    /// 64-bit floating point
     Float64,
+    /// String type
     String,
+    /// Error type (represents Result<None, String>)
     Error,
+    /// Interface type (for variants/discriminated unions)
     Interface,
+    /// Pointer to another type
     Pointer(Box<GoType>),
+    /// Result type with Ok value
     ValueOrOk(Box<GoType>),
+    /// Result type with Error value
     ValueOrError(Box<GoType>),
+    /// Slice/array of another type
     Slice(Box<GoType>),
+    /// User-defined type (records, enums, type aliases)
     UserDefined(String),
+    /// Represents no value/void
     Nothing,
 }
 
@@ -29,16 +53,19 @@ impl GoType {
     /// for types that allocate memory in the guest's linear memory when being returned.
     ///
     /// Types that need cleanup:
-    /// - Strings (allocate memory for the string data)
-    /// - Lists/Slices (allocate memory for the list elements)
-    /// - Records with fields that need cleanup
-    /// - Variants with cases that need cleanup
-    /// - Results with values that need cleanup
+    /// - Strings: allocate memory for the string data
+    /// - Lists/Slices: allocate memory for the array data
+    /// - Types containing the above (recursively)
     ///
-    /// Types that don't need cleanup:
-    /// - Primitive numeric types (passed by value)
-    /// - Booleans (passed by value)
-    /// - Empty results
+    /// Types that DON'T need cleanup:
+    /// - Primitives (bool, integers, floats): passed by value
+    /// - Enums: represented as integers
+    ///
+    /// Limitations:
+    /// - For UserDefined types (records, type aliases), we can't determine here if they
+    ///   contain strings/lists without the full type definition, so we're conservative
+    /// - A perfect implementation would recursively check record fields, but that would
+    ///   require passing the Resolve context here
     pub fn needs_cleanup(&self) -> bool {
         match self {
             // Primitive types don't need cleanup
@@ -52,40 +79,68 @@ impl GoType {
             | GoType::Int32
             | GoType::Int64
             | GoType::Float32
-            | GoType::Float64
-            | GoType::Interface
-            | GoType::Nothing => false,
+            | GoType::Float64 => false,
 
-            // String always needs cleanup
-            GoType::String => true,
+            // String and slices allocate memory and need cleanup
+            GoType::String | GoType::Slice(_) => true,
 
-            // Lists always need cleanup
-            GoType::Slice(_) => true,
+            // Complex types need cleanup if their inner types do
+            GoType::ValueOrOk(inner) => inner.needs_cleanup(),
 
-            // Pointers need cleanup if the inner type does
-            GoType::Pointer(inner) => inner.needs_cleanup(),
+            // The inner type of `Err` is always a String so it requires cleanup
+            // TODO(#91): Store the error type to check both inner types.
+            GoType::ValueOrError(_) => true,
 
-            // ValueOrOk and ValueOrError need cleanup if the inner type does
-            GoType::ValueOrOk(inner) | GoType::ValueOrError(inner) => inner.needs_cleanup(),
+            // Interfaces (variants) might need cleanup (conservative approach)
+            GoType::Interface => true,
 
-            // Error types typically need cleanup (they contain strings)
+            // User-defined types (records, enums, type aliases) need cleanup if they
+            // contain strings or other allocated types. Since we don't have access to
+            // the type definition here, we must be conservative and assume they might.
+            //
+            // This means we might generate unnecessary cleanup calls for:
+            // - Enums (which are just integers)
+            // - Records containing only primitives
+            // - Type aliases to primitives
+            //
+            // TODO(#92): Improve this by either:
+            // 1. Passing the Resolve context to check actual type definitions
+            // 2. Tracking cleanup requirements during type resolution
+            // 3. Using a different representation that carries this information
+            GoType::UserDefined(_) => true,
+
+            // Error is actually Result<None, String> - strings need cleanup!
             GoType::Error => true,
 
-            // User-defined types might need cleanup (conservatively return true)
-            // In practice, we'd need to look up the actual type definition
-            GoType::UserDefined(_) => true,
+            // Nothing represents no value, so no cleanup needed
+            GoType::Nothing => false,
+
+            // A pointer probably needs cleanup, not sure?
+            GoType::Pointer(_) => true,
         }
     }
 }
 
+/// Represents a Go function result type.
+///
+/// Can be either empty (no return value) or an anonymous type.
+/// Used for modeling function returns in the generated Go code.
 #[derive(Debug, Clone, PartialEq)]
 pub enum GoResult {
+    /// No return value
     Empty,
+    /// Anonymous return type
     Anon(GoType),
 }
 
 impl GoResult {
-    /// Returns true if this result type needs post-return cleanup
+    /// Returns true if this result type needs post-return cleanup.
+    ///
+    /// Delegates to the underlying type's cleanup requirements.
+    /// Empty results don't need cleanup as they represent no value.
+    ///
+    /// # Returns
+    /// `true` if cleanup is needed, `false` otherwise.
     pub fn needs_cleanup(&self) -> bool {
         match self {
             GoResult::Empty => false,
@@ -94,21 +149,93 @@ impl GoResult {
     }
 }
 
+/// Represents an operand in Go code generation.
+///
+/// Operands can be literals, single values (variables), or multi-value tuples
+/// (used for functions returning multiple values).
 #[derive(Debug, Clone, PartialEq)]
 pub enum Operand {
+    /// A literal value (e.g., "0", "true", "\"hello\"")
     Literal(String),
+    /// A single variable or expression
     SingleValue(String),
+    /// A tuple of two values (for multi-value returns)
     MultiValue((String, String)),
 }
 
 impl Operand {
-    /// Returns the primary value of the operand (for single values and literals)
-    /// or the first value of a multi-value tuple
+    /// Returns the primary value of the operand.
+    ///
+    /// For single values and literals, returns the value itself.
+    /// For multi-value tuples, returns the first value.
+    ///
+    /// # Returns
+    /// A string representation of the primary value.
     pub fn as_string(&self) -> String {
         match self {
             Operand::Literal(s) => s.clone(),
             Operand::SingleValue(s) => s.clone(),
             Operand::MultiValue((s1, _)) => s1.clone(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_needs_cleanup_primitives() {
+        // Primitives don't need cleanup
+        assert!(!GoType::Bool.needs_cleanup());
+        assert!(!GoType::Uint8.needs_cleanup());
+        assert!(!GoType::Uint16.needs_cleanup());
+        assert!(!GoType::Uint32.needs_cleanup());
+        assert!(!GoType::Uint64.needs_cleanup());
+        assert!(!GoType::Int8.needs_cleanup());
+        assert!(!GoType::Int16.needs_cleanup());
+        assert!(!GoType::Int32.needs_cleanup());
+        assert!(!GoType::Int64.needs_cleanup());
+        assert!(!GoType::Float32.needs_cleanup());
+        assert!(!GoType::Float64.needs_cleanup());
+    }
+
+    #[test]
+    fn test_needs_cleanup_allocated_types() {
+        // These types allocate memory and need cleanup
+        assert!(GoType::String.needs_cleanup());
+        assert!(GoType::Slice(Box::new(GoType::Uint8)).needs_cleanup());
+        assert!(GoType::Slice(Box::new(GoType::String)).needs_cleanup());
+        assert!(GoType::Error.needs_cleanup());
+    }
+
+    #[test]
+    fn test_needs_cleanup_complex_types() {
+        // ValueOrOk depends on inner type
+        assert!(!GoType::ValueOrOk(Box::new(GoType::Uint32)).needs_cleanup());
+        assert!(GoType::ValueOrOk(Box::new(GoType::String)).needs_cleanup());
+
+        // ValueOrError always needs cleanup (contains error which is a string)
+        assert!(GoType::ValueOrError(Box::new(GoType::Uint32)).needs_cleanup());
+        assert!(GoType::ValueOrError(Box::new(GoType::String)).needs_cleanup());
+
+        // Pointers always need cleanup (conservative approach)
+        assert!(GoType::Pointer(Box::new(GoType::Uint32)).needs_cleanup());
+        assert!(GoType::Pointer(Box::new(GoType::String)).needs_cleanup());
+    }
+
+    #[test]
+    fn test_needs_cleanup_special_types() {
+        assert!(GoType::Interface.needs_cleanup()); // Conservative
+        assert!(GoType::UserDefined("MyType".to_string()).needs_cleanup()); // Conservative
+        assert!(!GoType::Nothing.needs_cleanup()); // No value, no cleanup
+    }
+
+    #[test]
+    fn test_go_result_needs_cleanup() {
+        assert!(!GoResult::Empty.needs_cleanup());
+        assert!(!GoResult::Anon(GoType::Uint32).needs_cleanup());
+        assert!(GoResult::Anon(GoType::String).needs_cleanup());
+        assert!(GoResult::Anon(GoType::Slice(Box::new(GoType::Uint8))).needs_cleanup());
     }
 }

--- a/crates/gravity-wit/Cargo.toml
+++ b/crates/gravity-wit/Cargo.toml
@@ -4,10 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-wit-bindgen-core = "0.36"
-wit-parser = "0.220"
-wit-component = "0.220"
-anyhow = "1.0"
+wit-bindgen-core = { workspace = true }
+wit-component = { workspace = true }
+anyhow = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = "1.4"

--- a/crates/gravity-wit/Cargo.toml
+++ b/crates/gravity-wit/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "gravity-wit"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+wit-bindgen-core = "0.36"
+wit-parser = "0.220"
+wit-component = "0.220"
+anyhow = "1.0"
+
+[dev-dependencies]
+pretty_assertions = "1.4"

--- a/crates/gravity-wit/src/lib.rs
+++ b/crates/gravity-wit/src/lib.rs
@@ -3,7 +3,7 @@ pub mod resolver;
 use wit_bindgen_core::wit_parser::{Resolve, Type};
 
 /// Helper functions for working with WIT types
-pub fn size_of_type(resolve: &Resolve, ty: &Type) -> usize {
+pub fn size_of_type(_resolve: &Resolve, ty: &Type) -> usize {
     // TODO: Implement proper size calculation
     match ty {
         Type::Bool | Type::U8 | Type::S8 | Type::Char => 1,
@@ -12,7 +12,7 @@ pub fn size_of_type(resolve: &Resolve, ty: &Type) -> usize {
         Type::U64 | Type::S64 | Type::F64 => 8,
         Type::String => std::mem::size_of::<(*const u8, usize)>(),
         Type::ErrorContext => std::mem::size_of::<(*const u8, usize)>(), // Similar to string
-        Type::Id(id) => {
+        Type::Id(_id) => {
             // Look up the type definition and calculate its size
             // This is a placeholder - proper implementation needed
             8
@@ -20,7 +20,7 @@ pub fn size_of_type(resolve: &Resolve, ty: &Type) -> usize {
     }
 }
 
-pub fn align_of_type(resolve: &Resolve, ty: &Type) -> usize {
+pub fn align_of_type(_resolve: &Resolve, ty: &Type) -> usize {
     // TODO: Implement proper alignment calculation
     match ty {
         Type::Bool | Type::U8 | Type::S8 | Type::Char => 1,
@@ -29,7 +29,7 @@ pub fn align_of_type(resolve: &Resolve, ty: &Type) -> usize {
         Type::U64 | Type::S64 | Type::F64 => 8,
         Type::String => std::mem::align_of::<(*const u8, usize)>(),
         Type::ErrorContext => std::mem::align_of::<(*const u8, usize)>(), // Similar to string
-        Type::Id(id) => {
+        Type::Id(_id) => {
             // Look up the type definition and calculate its alignment
             // This is a placeholder - proper implementation needed
             8

--- a/crates/gravity-wit/src/lib.rs
+++ b/crates/gravity-wit/src/lib.rs
@@ -11,6 +11,7 @@ pub fn size_of_type(resolve: &Resolve, ty: &Type) -> usize {
         Type::U32 | Type::S32 | Type::F32 => 4,
         Type::U64 | Type::S64 | Type::F64 => 8,
         Type::String => std::mem::size_of::<(*const u8, usize)>(),
+        Type::ErrorContext => std::mem::size_of::<(*const u8, usize)>(), // Similar to string
         Type::Id(id) => {
             // Look up the type definition and calculate its size
             // This is a placeholder - proper implementation needed
@@ -27,6 +28,7 @@ pub fn align_of_type(resolve: &Resolve, ty: &Type) -> usize {
         Type::U32 | Type::S32 | Type::F32 => 4,
         Type::U64 | Type::S64 | Type::F64 => 8,
         Type::String => std::mem::align_of::<(*const u8, usize)>(),
+        Type::ErrorContext => std::mem::align_of::<(*const u8, usize)>(), // Similar to string
         Type::Id(id) => {
             // Look up the type definition and calculate its alignment
             // This is a placeholder - proper implementation needed

--- a/crates/gravity-wit/src/lib.rs
+++ b/crates/gravity-wit/src/lib.rs
@@ -1,0 +1,36 @@
+pub mod resolver;
+
+use wit_bindgen_core::wit_parser::{Resolve, Type};
+
+/// Helper functions for working with WIT types
+pub fn size_of_type(resolve: &Resolve, ty: &Type) -> usize {
+    // TODO: Implement proper size calculation
+    match ty {
+        Type::Bool | Type::U8 | Type::S8 | Type::Char => 1,
+        Type::U16 | Type::S16 => 2,
+        Type::U32 | Type::S32 | Type::F32 => 4,
+        Type::U64 | Type::S64 | Type::F64 => 8,
+        Type::String => std::mem::size_of::<(*const u8, usize)>(),
+        Type::Id(id) => {
+            // Look up the type definition and calculate its size
+            // This is a placeholder - proper implementation needed
+            8
+        }
+    }
+}
+
+pub fn align_of_type(resolve: &Resolve, ty: &Type) -> usize {
+    // TODO: Implement proper alignment calculation
+    match ty {
+        Type::Bool | Type::U8 | Type::S8 | Type::Char => 1,
+        Type::U16 | Type::S16 => 2,
+        Type::U32 | Type::S32 | Type::F32 => 4,
+        Type::U64 | Type::S64 | Type::F64 => 8,
+        Type::String => std::mem::align_of::<(*const u8, usize)>(),
+        Type::Id(id) => {
+            // Look up the type definition and calculate its alignment
+            // This is a placeholder - proper implementation needed
+            8
+        }
+    }
+}

--- a/crates/gravity-wit/src/resolver.rs
+++ b/crates/gravity-wit/src/resolver.rs
@@ -1,0 +1,35 @@
+use wit_bindgen_core::wit_parser::{Resolve, Type, TypeDef, TypeId};
+
+/// Resolves a type ID to its definition
+pub fn resolve_type(resolve: &Resolve, type_id: TypeId) -> Option<&TypeDef> {
+    resolve.types.get(type_id)
+}
+
+/// Gets the name of a type, handling anonymous types
+pub fn type_name(resolve: &Resolve, ty: &Type) -> String {
+    match ty {
+        Type::Bool => "bool".to_string(),
+        Type::Char => "char".to_string(),
+        Type::U8 => "uint8".to_string(),
+        Type::U16 => "uint16".to_string(),
+        Type::U32 => "uint32".to_string(),
+        Type::U64 => "uint64".to_string(),
+        Type::S8 => "int8".to_string(),
+        Type::S16 => "int16".to_string(),
+        Type::S32 => "int32".to_string(),
+        Type::S64 => "int64".to_string(),
+        Type::F32 => "float32".to_string(),
+        Type::F64 => "float64".to_string(),
+        Type::String => "string".to_string(),
+        Type::Id(id) => {
+            if let Some(type_def) = resolve_type(resolve, *id) {
+                type_def
+                    .name
+                    .clone()
+                    .unwrap_or_else(|| "anonymous".to_string())
+            } else {
+                "unknown".to_string()
+            }
+        }
+    }
+}

--- a/crates/gravity-wit/src/resolver.rs
+++ b/crates/gravity-wit/src/resolver.rs
@@ -21,6 +21,7 @@ pub fn type_name(resolve: &Resolve, ty: &Type) -> String {
         Type::F32 => "float32".to_string(),
         Type::F64 => "float64".to_string(),
         Type::String => "string".to_string(),
+        Type::ErrorContext => "error".to_string(),
         Type::Id(id) => {
             if let Some(type_def) = resolve_type(resolve, *id) {
                 type_def

--- a/docs/refactoring-plan.md
+++ b/docs/refactoring-plan.md
@@ -1,0 +1,362 @@
+# Gravity Refactoring Plan
+
+## Overview
+
+The current Gravity codebase consists of a single 2600+ line `main.rs` file, making it difficult to test individual components and understand the code structure. This plan outlines a refactoring strategy to create a modular, testable architecture.
+
+## Current Problems
+
+1. **Monolithic Structure**: Everything in one file makes navigation difficult
+2. **Limited Testing**: Can only do end-to-end UI tests, no unit tests
+3. **Tight Coupling**: Code generation, type resolution, and formatting are intertwined
+4. **Hard to Extend**: Adding new features requires understanding the entire file
+5. **Code Duplication**: Similar patterns repeated without reusable abstractions
+
+## Proposed Architecture
+
+```
+gravity/
+├── cmd/
+│   └── gravity/
+│       ├── src/
+│       │   ├── main.rs              # CLI entry point only
+│       │   └── lib.rs               # Library root
+│       ├── Cargo.toml
+│       └── tests/
+│           └── integration/          # End-to-end tests
+└── crates/
+    ├── gravity-codegen/              # Core code generation
+    │   ├── src/
+    │   │   ├── lib.rs
+    │   │   ├── types.rs             # GoType, GoResult, etc.
+    │   │   ├── instructions.rs      # Instruction handlers
+    │   │   ├── bindings.rs          # Bindings generator
+    │   │   └── context.rs           # Generation context
+    │   └── tests/
+    ├── gravity-go/                   # Go-specific formatting
+    │   ├── src/
+    │   │   ├── lib.rs
+    │   │   ├── identifier.rs        # GoIdentifier
+    │   │   ├── formatter.rs         # FormatInto implementations
+    │   │   └── imports.rs           # Import management
+    │   └── tests/
+    └── gravity-wit/                  # WIT parsing helpers
+        ├── src/
+        │   ├── lib.rs
+        │   └── resolver.rs           # Type resolution helpers
+        └── tests/
+```
+
+## Refactoring Phases
+
+### Phase 1: Extract Type System (Week 1)
+
+**Goal**: Move type definitions and formatting to separate modules
+
+**Files to create**:
+- `crates/gravity-go/src/types.rs`:
+  - `GoType` enum
+  - `GoResult` enum  
+  - `Operand` enum
+- `crates/gravity-go/src/formatter.rs`:
+  - `FormatInto` implementations
+  - Comment generation helpers
+
+**Benefits**:
+- Can unit test type formatting independently
+- Clear separation of Go-specific logic
+
+**Example test**:
+```rust
+#[test]
+fn test_optional_type_formatting() {
+    let typ = GoType::ValueOrOk(Box::new(GoType::Uint32));
+    let mut tokens = Tokens::new();
+    typ.format_into(&mut tokens);
+    assert_eq!(tokens.to_string(), "uint32, bool");
+}
+```
+
+### Phase 2: Extract Instruction Handling (Week 1-2)
+
+**Goal**: Separate instruction implementations from main logic
+
+**Structure**:
+```rust
+// crates/gravity-codegen/src/instructions/mod.rs
+pub trait InstructionHandler {
+    fn handle(
+        &mut self,
+        instruction: &Instruction,
+        context: &mut GenerationContext,
+    ) -> Result<Vec<Operand>, Error>;
+}
+
+// crates/gravity-codegen/src/instructions/option.rs
+pub struct OptionLiftHandler;
+impl InstructionHandler for OptionLiftHandler { ... }
+
+// crates/gravity-codegen/src/instructions/record.rs  
+pub struct RecordLiftHandler;
+impl InstructionHandler for RecordLiftHandler { ... }
+```
+
+**Benefits**:
+- Each instruction can be tested in isolation
+- Easy to add new instructions
+- Clear documentation per instruction
+
+### Phase 3: Extract Bindings Generator (Week 2)
+
+**Goal**: Separate the high-level binding generation from instruction handling
+
+**Structure**:
+```rust
+// crates/gravity-codegen/src/bindings.rs
+pub struct BindingsGenerator {
+    output: Tokens<Go>,
+    types: Vec<TypeDef>,
+}
+
+impl BindingsGenerator {
+    pub fn new() -> Self { ... }
+    pub fn add_type(&mut self, type_def: &TypeDef) { ... }
+    pub fn add_function(&mut self, func: &Function) { ... }
+    pub fn generate(self) -> String { ... }
+}
+```
+
+**Benefits**:
+- Can test type and function generation separately
+- Mock different WIT configurations easily
+- Reusable for different output formats
+
+### Phase 4: Create Builder Pattern for Complex Types (Week 2-3)
+
+**Goal**: Make complex type construction more testable and readable
+
+**Example**:
+```rust
+// crates/gravity-codegen/src/builders.rs
+pub struct StructBuilder {
+    name: String,
+    fields: Vec<(String, GoType)>,
+}
+
+impl StructBuilder {
+    pub fn new(name: impl Into<String>) -> Self { ... }
+    pub fn field(mut self, name: impl Into<String>, typ: GoType) -> Self { ... }
+    pub fn build(self) -> Tokens<Go> { ... }
+}
+
+// Usage in tests:
+let struct_tokens = StructBuilder::new("Person")
+    .field("name", GoType::String)
+    .field("age", GoType::Uint32)
+    .field("email", GoType::Pointer(Box::new(GoType::String)))
+    .build();
+```
+
+### Phase 5: Integration Layer (Week 3)
+
+**Goal**: Create clean integration between components
+
+**Structure**:
+```rust
+// crates/gravity-codegen/src/lib.rs
+pub struct CodeGenerator {
+    instruction_registry: InstructionRegistry,
+    bindings_generator: BindingsGenerator,
+    context: GenerationContext,
+}
+
+impl CodeGenerator {
+    pub fn from_component(component: &[u8]) -> Result<Self, Error> { ... }
+    pub fn generate_go(self) -> Result<String, Error> { ... }
+}
+```
+
+## Testing Strategy
+
+### Unit Tests
+
+Each module should have comprehensive unit tests:
+
+```rust
+// crates/gravity-go/src/types.rs
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_pointer_type_in_struct_field() {
+        // Test that ValueOrOk becomes Pointer in struct context
+    }
+
+    #[test]
+    fn test_multivalue_in_function_return() {
+        // Test that ValueOrOk becomes tuple in function context
+    }
+}
+```
+
+### Integration Tests
+
+```rust
+// crates/gravity-codegen/tests/integration.rs
+#[test]
+fn test_optional_field_conversion() {
+    let wit = r#"
+        record person {
+            name: string,
+            email: option<string>,
+        }
+    "#;
+    let generator = CodeGenerator::from_wit(wit).unwrap();
+    let go_code = generator.generate_go().unwrap();
+    assert!(go_code.contains("Email *string"));
+}
+```
+
+### Property-Based Testing
+
+Use `proptest` for complex scenarios:
+
+```rust
+proptest! {
+    #[test]
+    fn test_variant_name_prefixing(
+        variant_name in "[a-z-]+",
+        case_names in prop::collection::vec("[a-z-]+", 1..10)
+    ) {
+        // Test that all case names are properly prefixed
+        // and no collisions occur
+    }
+}
+```
+
+## Migration Strategy
+
+### Step 1: Create Module Structure (Day 1)
+- Create new crate structure
+- Set up Cargo.toml files
+- Keep main.rs unchanged
+
+### Step 2: Extract Without Breaking (Days 2-5)
+- Copy (don't move) types to new modules
+- Add `pub use` statements in main.rs
+- Ensure everything still compiles
+
+### Step 3: Gradual Migration (Week 2)
+- Replace main.rs code with calls to modules
+- One instruction at a time
+- Keep tests passing throughout
+
+### Step 4: Remove Duplication (Week 3)
+- Delete old code from main.rs
+- Update imports
+- Final cleanup
+
+## Success Metrics
+
+1. **Code Coverage**: Achieve >80% unit test coverage
+2. **Compilation Time**: No significant increase in build time
+3. **Performance**: No regression in code generation speed
+4. **Modularity**: Each crate under 500 lines
+5. **Documentation**: Every public API documented
+
+## Benefits
+
+### Immediate Benefits
+- **Easier Testing**: Can test individual components
+- **Better Organization**: Clear module boundaries
+- **Faster Development**: Parallel work on different modules
+- **Easier Onboarding**: New contributors can understand smaller pieces
+
+### Long-term Benefits
+- **Extensibility**: Easy to add new output formats (not just Go)
+- **Reusability**: Other tools can use gravity as a library
+- **Maintainability**: Bugs isolated to specific modules
+- **Performance**: Can optimize hot paths independently
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Breaking existing functionality | High | Incremental migration with tests at each step |
+| Over-engineering | Medium | Start simple, refactor as needed |
+| Lost context during refactor | Medium | Extensive comments and documentation |
+| Merge conflicts | Low | Coordinate refactoring in focused sprints |
+
+## Example: Refactored Option Handling
+
+Before (in main.rs):
+```rust
+// 1000+ lines into the file...
+Instruction::OptionLift { payload, .. } => {
+    // 30 lines of inline code
+}
+```
+
+After:
+```rust
+// crates/gravity-codegen/src/instructions/option.rs
+pub struct OptionLift;
+
+impl OptionLift {
+    pub fn handle(context: &mut GenContext, payload: &Type) -> Result<()> {
+        // Same logic, but testable
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_option_lift_generates_tuple() {
+        let mut context = GenContext::mock();
+        OptionLift::handle(&mut context, &Type::String).unwrap();
+        assert_eq!(context.operands.last(), Some(&Operand::MultiValue(...)));
+    }
+}
+```
+
+## Timeline
+
+- **Week 1**: Extract types and formatting
+- **Week 2**: Extract instruction handlers
+- **Week 3**: Create integration layer and migrate
+- **Week 4**: Documentation and cleanup
+
+## Next Steps
+
+1. Review and approve this plan
+2. Create feature branch for refactoring
+3. Set up new crate structure
+4. Begin Phase 1 extraction
+5. Write initial unit tests as we go
+
+## Appendix: Module Responsibilities
+
+### gravity-go
+- Go language specifics
+- Identifier formatting (public/private/local)
+- Import management
+- Go type representations
+
+### gravity-codegen
+- Instruction handling
+- Function generation
+- Bindgen trait implementation
+- Context management
+
+### gravity-wit
+- WIT parsing helpers
+- Type resolution
+- Component model understanding
+- Size calculations
+
+### cmd/gravity
+- CLI argument parsing
+- File I/O
+- Error reporting to user
+- Integration of all modules

--- a/docs/resources-plan.md
+++ b/docs/resources-plan.md
@@ -1,0 +1,242 @@
+# Resources Implementation Plan for Gravity
+
+## Overview
+
+Resources are stateful objects in the Component Model that represent entities that exist outside of the component and should be passed by reference rather than by value. This document outlines the plan to add resource support to Gravity.
+
+## Motivation
+
+Resources enable several key use cases:
+- File handles and I/O streams
+- Database connections
+- Network sockets
+- Cryptographic contexts
+- Any stateful host-provided API
+
+## Current Status
+
+As of now, Gravity has:
+- ✅ Basic types (string, u32, etc.)
+- ✅ Option types (`option<T>`)
+- ✅ Result types (`result<T, E>`)
+- ✅ Records (structs)
+- ✅ Variants (with prefixed names)
+- ✅ Lists/arrays
+- ❌ Resources (TODO #5)
+- ❌ Handles (TODO #5)
+
+## Implementation Phases
+
+### Phase 1: Basic Resource Types (Week 1-2)
+
+**Goal**: Generate Go types for resources without methods
+
+**Tasks**:
+1. Update `TypeDefKind::Resource` handling in `define_type()`
+2. Generate basic Go struct with handle field
+3. Add resource handle tracking to factory/instance
+
+**Example WIT**:
+```wit
+resource blob {
+    constructor(init: list<u8>);
+}
+```
+
+**Generated Go**:
+```go
+type Blob struct {
+    handle uint32
+    instance *OutlierInstance
+}
+
+func (i *OutlierInstance) NewBlob(ctx context.Context, init []uint8) (*Blob, error) {
+    // Call constructor
+    handle, err := i.module.ExportedFunction("blob-new").Call(ctx, ...)
+    return &Blob{handle: handle, instance: i}, err
+}
+```
+
+### Phase 2: Resource Methods (Week 2-3)
+
+**Goal**: Support method calls on resources
+
+**Tasks**:
+1. Parse resource methods from WIT
+2. Generate Go methods that pass handle as first parameter
+3. Handle `self: borrow<resource>` parameters
+
+**Example**:
+```go
+func (b *Blob) Write(ctx context.Context, bytes []uint8) error {
+    _, err := b.instance.module.ExportedFunction("blob-write").Call(
+        ctx, 
+        uint64(b.handle),
+        // ... other parameters
+    )
+    return err
+}
+```
+
+### Phase 3: Resource Lifecycle (Week 3-4)
+
+**Goal**: Proper cleanup and ownership tracking
+
+**Tasks**:
+1. Add destructor support (`Close()` methods)
+2. Track resource ownership (owned vs borrowed)
+3. Prevent use-after-free
+
+**Implementation**:
+```go
+type ResourceManager struct {
+    sync.RWMutex
+    handles  map[uint32]interface{}
+    nextID   uint32
+    closed   map[uint32]bool
+}
+
+func (b *Blob) Close(ctx context.Context) error {
+    if b.instance.resources.IsClosed(b.handle) {
+        return errors.New("resource already closed")
+    }
+    _, err := b.instance.module.ExportedFunction("blob-drop").Call(ctx, uint64(b.handle))
+    b.instance.resources.MarkClosed(b.handle)
+    return err
+}
+```
+
+### Phase 4: Static Functions (Week 4)
+
+**Goal**: Support static resource functions
+
+**Example**:
+```wit
+resource blob {
+    merge: static func(lhs: blob, rhs: blob) -> blob;
+}
+```
+
+**Generated Go**:
+```go
+func (i *OutlierInstance) BlobMerge(ctx context.Context, lhs *Blob, rhs *Blob) (*Blob, error) {
+    // Static function - no implicit self parameter
+    handle, err := i.module.ExportedFunction("blob-merge").Call(
+        ctx,
+        uint64(lhs.handle),
+        uint64(rhs.handle),
+    )
+    // ...
+}
+```
+
+### Phase 5: Advanced Features (Week 5+)
+
+**Goal**: Handle complex resource patterns
+
+**Tasks**:
+1. Resources as parameters/return values in regular functions
+2. Resources in records and variants
+3. Optional resources (`option<resource>`)
+4. Lists of resources (`list<resource>`)
+
+## Technical Details
+
+### Instructions to Implement
+
+New instructions needed:
+- `ResourceNew` - constructor calls
+- `ResourceRep` - get handle representation
+- `ResourceDrop` - destructor calls
+- `HandleOwned` - owned handle operations
+- `HandleBorrowed` - borrowed handle operations
+
+### Code Changes Required
+
+1. **main.rs**:
+   - Add `GoType::Resource(String)` variant
+   - Implement `ResourceNew`, `ResourceRep`, `ResourceDrop` instructions
+   - Update `define_type()` for `TypeDefKind::Resource`
+
+2. **Generated Go Code**:
+   - Resource struct with handle
+   - Constructor functions
+   - Method receivers
+   - Close/cleanup methods
+   - Resource manager integration
+
+### Testing Strategy
+
+1. **Unit Tests**:
+   - Simple resource creation/destruction
+   - Method calls
+   - Static functions
+
+2. **Integration Tests**:
+   - Resource lifecycle across multiple calls
+   - Error handling (invalid handles)
+   - Concurrent access
+
+3. **Example Components**:
+   - File I/O resource
+   - Database connection pool
+   - HTTP client resource
+
+## Open Questions
+
+1. **Finalizers**: Should we use Go finalizers for automatic cleanup?
+   - Pro: Prevents leaks
+   - Con: Non-deterministic, performance impact
+
+2. **Thread Safety**: How to handle concurrent access?
+   - Option A: All methods take locks
+   - Option B: Leave to user
+   - Option C: Document as not thread-safe
+
+3. **Handle Format**: uint32 vs opaque type?
+   - uint32 is simple but allows mistakes
+   - Opaque type is safer but more complex
+
+4. **Error Recovery**: What if Wasm panics while holding resources?
+   - Need cleanup in defer blocks
+   - Track all active resources per instance
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Memory leaks from unclosed resources | High | Finalizers + leak detection in tests |
+| Use-after-free bugs | High | Track closed handles, return errors |
+| Complex ownership semantics | Medium | Clear documentation, examples |
+| Performance overhead of handle tracking | Low | Use efficient maps, lazy initialization |
+
+## Success Criteria
+
+- [ ] Basic resource types compile without errors
+- [ ] Constructor and destructor calls work
+- [ ] Methods can be called on resources
+- [ ] Static functions work
+- [ ] Resources can be passed as parameters
+- [ ] No memory leaks in typical usage
+- [ ] Clear documentation and examples
+
+## Timeline Estimate
+
+- **Phase 1-2**: 2-3 weeks (basic functionality)
+- **Phase 3-4**: 1-2 weeks (lifecycle and static functions)
+- **Phase 5**: 2+ weeks (advanced features)
+- **Total**: 5-7 weeks for full implementation
+
+## Next Steps
+
+1. Review and approve this plan
+2. Create tracking issue for resources
+3. Start with Phase 1 implementation
+4. Create test WIT files with resource definitions
+5. Document Go usage patterns as we implement
+
+## References
+
+- [Component Model Resources Spec](https://component-model.bytecodealliance.org/design/wit.html#resources)
+- [Canonical ABI for Resources](https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#resources)
+- [wit-bindgen Resource Handling](https://github.com/bytecodealliance/wit-bindgen)

--- a/examples/generate.go
+++ b/examples/generate.go
@@ -7,8 +7,8 @@ package examples
 // This quoting was a nightmare to get right, had to use a subshell in the end.
 //go:generate sh -c "RUSTFLAGS='--cfg getrandom_backend=\"custom\"' cargo build -p example-outlier --target wasm32-unknown-unknown --release"
 
-//go:generate cargo run --bin gravity -- --world basic --output ./basic/basic.go ../target/wasm32-unknown-unknown/release/example_basic.wasm
-//go:generate cargo run --bin gravity -- --world records --output ./records/records.go ../target/wasm32-unknown-unknown/release/example_records.wasm
-//go:generate cargo run --bin gravity -- --world example --output ./iface-method-returns-string/example.go ../target/wasm32-unknown-unknown/release/example_iface_method_returns_string.wasm
-//go:generate cargo run --bin gravity -- --world instructions --output ./instructions/bindings.go ../target/wasm32-unknown-unknown/release/example_instructions.wasm
-//go:generate cargo run --bin gravity -- --world outlier --output ./outlier/outlier.go ../target/wasm32-unknown-unknown/release/example_outlier.wasm
+//go:generate cargo run --bin gravity2 -- --world basic --output ./basic/basic.go ../target/wasm32-unknown-unknown/release/example_basic.wasm
+//go:generate cargo run --bin gravity2 -- --world records --output ./records/records.go ../target/wasm32-unknown-unknown/release/example_records.wasm
+//go:generate cargo run --bin gravity2 -- --world example --output ./iface-method-returns-string/example.go ../target/wasm32-unknown-unknown/release/example_iface_method_returns_string.wasm
+//go:generate cargo run --bin gravity2 -- --world instructions --output ./instructions/bindings.go ../target/wasm32-unknown-unknown/release/example_instructions.wasm
+//go:generate cargo run --bin gravity2 -- --world outlier --output ./outlier/outlier.go ../target/wasm32-unknown-unknown/release/example_outlier.wasm

--- a/examples/generate.go
+++ b/examples/generate.go
@@ -2,6 +2,8 @@ package examples
 
 //go:generate cargo build -p example-basic --target wasm32-unknown-unknown --release
 //go:generate cargo build -p example-iface-method-returns-string --target wasm32-unknown-unknown --release
+//go:generate cargo build -p example-instructions --target wasm32-unknown-unknown --release
 
 //go:generate cargo run --bin gravity -- --world basic --output ./basic/basic.go ../target/wasm32-unknown-unknown/release/example_basic.wasm
 //go:generate cargo run --bin gravity -- --world example --output ./iface-method-returns-string/example.go ../target/wasm32-unknown-unknown/release/example_iface_method_returns_string.wasm
+//go:generate cargo run --bin gravity -- --world instructions --output ./instructions/bindings.go ../target/wasm32-unknown-unknown/release/example_instructions.wasm

--- a/examples/generate.go
+++ b/examples/generate.go
@@ -4,8 +4,11 @@ package examples
 //go:generate cargo build -p example-records --target wasm32-unknown-unknown --release
 //go:generate cargo build -p example-iface-method-returns-string --target wasm32-unknown-unknown --release
 //go:generate cargo build -p example-instructions --target wasm32-unknown-unknown --release
+// This quoting was a nightmare to get right, had to use a subshell in the end.
+//go:generate sh -c "RUSTFLAGS='--cfg getrandom_backend=\"custom\"' cargo build -p example-outlier --target wasm32-unknown-unknown --release"
 
 //go:generate cargo run --bin gravity -- --world basic --output ./basic/basic.go ../target/wasm32-unknown-unknown/release/example_basic.wasm
 //go:generate cargo run --bin gravity -- --world records --output ./records/records.go ../target/wasm32-unknown-unknown/release/example_records.wasm
 //go:generate cargo run --bin gravity -- --world example --output ./iface-method-returns-string/example.go ../target/wasm32-unknown-unknown/release/example_iface_method_returns_string.wasm
 //go:generate cargo run --bin gravity -- --world instructions --output ./instructions/bindings.go ../target/wasm32-unknown-unknown/release/example_instructions.wasm
+//go:generate cargo run --bin gravity -- --world outlier --output ./outlier/bindings.go ../target/wasm32-unknown-unknown/release/example_outlier.wasm

--- a/examples/generate.go
+++ b/examples/generate.go
@@ -11,4 +11,4 @@ package examples
 //go:generate cargo run --bin gravity -- --world records --output ./records/records.go ../target/wasm32-unknown-unknown/release/example_records.wasm
 //go:generate cargo run --bin gravity -- --world example --output ./iface-method-returns-string/example.go ../target/wasm32-unknown-unknown/release/example_iface_method_returns_string.wasm
 //go:generate cargo run --bin gravity -- --world instructions --output ./instructions/bindings.go ../target/wasm32-unknown-unknown/release/example_instructions.wasm
-//go:generate cargo run --bin gravity -- --world outlier --output ./outlier/bindings.go ../target/wasm32-unknown-unknown/release/example_outlier.wasm
+//go:generate cargo run --bin gravity -- --world outlier --output ./outlier/outlier.go ../target/wasm32-unknown-unknown/release/example_outlier.wasm

--- a/examples/generate.go
+++ b/examples/generate.go
@@ -1,9 +1,11 @@
 package examples
 
 //go:generate cargo build -p example-basic --target wasm32-unknown-unknown --release
+//go:generate cargo build -p example-record --target wasm32-unknown-unknown --release
 //go:generate cargo build -p example-iface-method-returns-string --target wasm32-unknown-unknown --release
 //go:generate cargo build -p example-instructions --target wasm32-unknown-unknown --release
 
 //go:generate cargo run --bin gravity -- --world basic --output ./basic/basic.go ../target/wasm32-unknown-unknown/release/example_basic.wasm
+//go:generate cargo run --bin gravity -- --world records --output ./records/records.go ../target/wasm32-unknown-unknown/release/example_records.wasm
 //go:generate cargo run --bin gravity -- --world example --output ./iface-method-returns-string/example.go ../target/wasm32-unknown-unknown/release/example_iface_method_returns_string.wasm
 //go:generate cargo run --bin gravity -- --world instructions --output ./instructions/bindings.go ../target/wasm32-unknown-unknown/release/example_instructions.wasm

--- a/examples/generate.go
+++ b/examples/generate.go
@@ -1,7 +1,7 @@
 package examples
 
 //go:generate cargo build -p example-basic --target wasm32-unknown-unknown --release
-//go:generate cargo build -p example-record --target wasm32-unknown-unknown --release
+//go:generate cargo build -p example-records --target wasm32-unknown-unknown --release
 //go:generate cargo build -p example-iface-method-returns-string --target wasm32-unknown-unknown --release
 //go:generate cargo build -p example-instructions --target wasm32-unknown-unknown --release
 

--- a/examples/instructions/Cargo.toml
+++ b/examples/instructions/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "example-instructions"
+version = "0.0.2"
+edition = "2024"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = "=0.42.1"
+wit-component = "=0.230.0"

--- a/examples/instructions/instructions_test.go
+++ b/examples/instructions/instructions_test.go
@@ -1,4 +1,4 @@
-package basic
+package instructions
 
 import (
 	"testing"

--- a/examples/instructions/instructions_test.go
+++ b/examples/instructions/instructions_test.go
@@ -57,7 +57,7 @@ func TestI32FromU8(t *testing.T) {
 	}
 	defer ins.Close(t.Context())
 
-	for x := math.MinUint8; x <= math.MaxUint8; x++ {
+	for x := 0; x <= math.MaxUint8; x++ {
 		ins.I32FromU8(t.Context(), uint8(x))
 	}
 }

--- a/examples/instructions/instructions_test.go
+++ b/examples/instructions/instructions_test.go
@@ -82,3 +82,81 @@ func TestU8FromI32(t *testing.T) {
 		t.Errorf("expected: %d, but got: %d", expected, actual)
 	}
 }
+
+func TestI32FromS16(t *testing.T) {
+	fac, err := NewInstructionsFactory(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fac.Close(t.Context())
+
+	ins, err := fac.Instantiate(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ins.Close(t.Context())
+
+	for x := math.MinInt16; x <= math.MaxInt16; x++ {
+		ins.I32FromS16(t.Context(), int16(x))
+	}
+}
+
+func TestS16FromI32(t *testing.T) {
+	fac, err := NewInstructionsFactory(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fac.Close(t.Context())
+
+	ins, err := fac.Instantiate(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ins.Close(t.Context())
+
+	actual := ins.S16FromI32(t.Context())
+
+	const expected = 0
+	if actual != expected {
+		t.Errorf("expected: %d, but got: %d", expected, actual)
+	}
+}
+
+func TestI32FromU16(t *testing.T) {
+	fac, err := NewInstructionsFactory(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fac.Close(t.Context())
+
+	ins, err := fac.Instantiate(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ins.Close(t.Context())
+
+	for x := 0; x <= math.MaxUint16; x++ {
+		ins.I32FromU16(t.Context(), uint16(x))
+	}
+}
+
+func TestU16FromI32(t *testing.T) {
+	fac, err := NewInstructionsFactory(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fac.Close(t.Context())
+
+	ins, err := fac.Instantiate(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ins.Close(t.Context())
+
+	actual := ins.U16FromI32(t.Context())
+
+	const expected = 0
+	if actual != expected {
+		t.Errorf("expected: %d, but got: %d", expected, actual)
+	}
+}

--- a/examples/instructions/instructions_test.go
+++ b/examples/instructions/instructions_test.go
@@ -21,6 +21,25 @@ func inclusive[Num interface { ~int8 | ~uint8 | ~int16 | ~uint16 }](start Num, e
 		}
 	}
 }
+func inclusiveStep[Num interface { ~int32 | ~uint32 }](start Num, end Num, step Num) iter.Seq[Num] {
+	return func(yield func(v Num) bool) {
+		var next Num = start
+		for {
+			if !yield(next) {
+				return
+			}
+			if next == end {
+				return
+			}
+
+			if end - step > next {
+				next += step
+			} else {
+				next = end
+			}
+		}
+	}
+}
 
 func Test_S8Roundtrip(t *testing.T) {
 	fac, err := NewInstructionsFactory(t.Context())
@@ -100,6 +119,48 @@ func Test_U16Roundtrip(t *testing.T) {
 
 	for expected := range inclusive[uint16](0, math.MaxUint16) {
 		actual := ins.U16Roundtrip(t.Context(), expected)
+		if actual != expected {
+			t.Errorf("expected: %d, but got: %d", expected, actual)
+		}
+	}
+}
+
+func Test_S32Roundtrip(t *testing.T) {
+	fac, err := NewInstructionsFactory(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fac.Close(t.Context())
+
+	ins, err := fac.Instantiate(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ins.Close(t.Context())
+
+	for expected := range inclusiveStep[int32](math.MinInt32, math.MaxInt32, 10_000) {
+		actual := ins.S32Roundtrip(t.Context(), expected)
+		if actual != expected {
+			t.Errorf("expected: %d, but got: %d", expected, actual)
+		}
+	}
+}
+
+func Test_U32Roundtrip(t *testing.T) {
+	fac, err := NewInstructionsFactory(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fac.Close(t.Context())
+
+	ins, err := fac.Instantiate(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ins.Close(t.Context())
+
+	for expected := range inclusiveStep[uint32](0, math.MaxUint32, 10_000) {
+		actual := ins.U32Roundtrip(t.Context(), expected)
 		if actual != expected {
 			t.Errorf("expected: %d, but got: %d", expected, actual)
 		}

--- a/examples/instructions/instructions_test.go
+++ b/examples/instructions/instructions_test.go
@@ -1,6 +1,7 @@
 package instructions
 
 import (
+	"math"
 	"testing"
 )
 

--- a/examples/instructions/instructions_test.go
+++ b/examples/instructions/instructions_test.go
@@ -42,7 +42,7 @@ func Test_U8Roundtrip(t *testing.T) {
 
 	var expected uint8
 	for expected = 0; expected <= math.MaxUint8; expected++ {
-		actual := ins.TestU8Roundtrip(t.Context(), expected)
+		actual := ins.U8Roundtrip(t.Context(), expected)
 		if actual != expected {
 			t.Errorf("expected: %d, but got: %d", expected, actual)
 		}

--- a/examples/instructions/instructions_test.go
+++ b/examples/instructions/instructions_test.go
@@ -1,0 +1,23 @@
+package basic
+
+import (
+	"testing"
+)
+
+func TestI32FromS8(t *testing.T) {
+	fac, err := NewBasicFactory(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fac.Close(t.Context())
+
+	ins, err := fac.Instantiate(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ins.Close(t.Context())
+
+	for x := math.MinInt8; x <= math.MaxInt8; x++ {
+		ins.I32FromS8(t.Context(), int8(x))
+	}
+}

--- a/examples/instructions/instructions_test.go
+++ b/examples/instructions/instructions_test.go
@@ -96,7 +96,7 @@ func Test_S16Roundtrip(t *testing.T) {
 	}
 	defer ins.Close(t.Context())
 
-	for expected := range inclusive[int16](math.MaxInt16, math.MaxInt16) {
+	for expected := range inclusive[int16](math.MinInt16, math.MaxInt16) {
 		actual := ins.S16Roundtrip(t.Context(), expected)
 		if actual != expected {
 			t.Errorf("expected: %d, but got: %d", expected, actual)

--- a/examples/instructions/instructions_test.go
+++ b/examples/instructions/instructions_test.go
@@ -22,3 +22,24 @@ func TestI32FromS8(t *testing.T) {
 		ins.I32FromS8(t.Context(), int8(x))
 	}
 }
+
+func TestS8FromI32(t *testing.T) {
+	fac, err := NewInstructionsFactory(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fac.Close(t.Context())
+
+	ins, err := fac.Instantiate(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ins.Close(t.Context())
+
+	actual := ins.S8FromI32(t.Context())
+
+	const expected = 0
+	if actual != expected {
+		t.Errorf("expected: %d, but got: %d", expected, actual)
+	}
+}

--- a/examples/instructions/instructions_test.go
+++ b/examples/instructions/instructions_test.go
@@ -43,3 +43,42 @@ func TestS8FromI32(t *testing.T) {
 		t.Errorf("expected: %d, but got: %d", expected, actual)
 	}
 }
+
+func TestI32FromU8(t *testing.T) {
+	fac, err := NewInstructionsFactory(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fac.Close(t.Context())
+
+	ins, err := fac.Instantiate(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ins.Close(t.Context())
+
+	for x := math.MinUint8; x <= math.MaxUint8; x++ {
+		ins.I32FromU8(t.Context(), uint8(x))
+	}
+}
+
+func TestU8FromI32(t *testing.T) {
+	fac, err := NewInstructionsFactory(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fac.Close(t.Context())
+
+	ins, err := fac.Instantiate(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ins.Close(t.Context())
+
+	actual := ins.U8FromI32(t.Context())
+
+	const expected = 0
+	if actual != expected {
+		t.Errorf("expected: %d, but got: %d", expected, actual)
+	}
+}

--- a/examples/instructions/instructions_test.go
+++ b/examples/instructions/instructions_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestI32FromS8(t *testing.T) {
+func Test_S8Roundtrip(t *testing.T) {
 	fac, err := NewInstructionsFactory(t.Context())
 	if err != nil {
 		t.Fatal(err)
@@ -18,12 +18,15 @@ func TestI32FromS8(t *testing.T) {
 	}
 	defer ins.Close(t.Context())
 
-	for x := math.MinInt8; x <= math.MaxInt8; x++ {
-		ins.I32FromS8(t.Context(), int8(x))
+	for expected := math.MinInt8; expected <= math.MaxInt8; expected++ {
+		actual := ins.S8Roundtrip(t.Context(), int8(expected))
+		if actual != expected {
+			t.Errorf("expected: %d, but got: %d", expected, actual)
+		}
 	}
 }
 
-func TestS8FromI32(t *testing.T) {
+func Test_U8Roundtrip(t *testing.T) {
 	fac, err := NewInstructionsFactory(t.Context())
 	if err != nil {
 		t.Fatal(err)
@@ -36,15 +39,15 @@ func TestS8FromI32(t *testing.T) {
 	}
 	defer ins.Close(t.Context())
 
-	actual := ins.S8FromI32(t.Context())
-
-	const expected = 0
-	if actual != expected {
-		t.Errorf("expected: %d, but got: %d", expected, actual)
+	for expected := 0; expected <= math.MaxUint8; expected++ {
+		actual := ins.TestU8Roundtrip(t.Context(), uint8(expected))
+		if actual != expected {
+			t.Errorf("expected: %d, but got: %d", expected, actual)
+		}
 	}
 }
 
-func TestI32FromU8(t *testing.T) {
+func Test_S16Roundtrip(t *testing.T) {
 	fac, err := NewInstructionsFactory(t.Context())
 	if err != nil {
 		t.Fatal(err)
@@ -57,12 +60,15 @@ func TestI32FromU8(t *testing.T) {
 	}
 	defer ins.Close(t.Context())
 
-	for x := 0; x <= math.MaxUint8; x++ {
-		ins.I32FromU8(t.Context(), uint8(x))
+	for expected := math.MinInt16; expected <= math.MaxInt16; expected++ {
+		actual := ins.S16Roundtrip(t.Context(), int16(expected))
+		if actual != expected {
+			t.Errorf("expected: %d, but got: %d", expected, actual)
+		}
 	}
 }
 
-func TestU8FromI32(t *testing.T) {
+func Test_U16Roundtrip(t *testing.T) {
 	fac, err := NewInstructionsFactory(t.Context())
 	if err != nil {
 		t.Fatal(err)
@@ -75,88 +81,10 @@ func TestU8FromI32(t *testing.T) {
 	}
 	defer ins.Close(t.Context())
 
-	actual := ins.U8FromI32(t.Context())
-
-	const expected = 0
-	if actual != expected {
-		t.Errorf("expected: %d, but got: %d", expected, actual)
-	}
-}
-
-func TestI32FromS16(t *testing.T) {
-	fac, err := NewInstructionsFactory(t.Context())
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer fac.Close(t.Context())
-
-	ins, err := fac.Instantiate(t.Context())
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer ins.Close(t.Context())
-
-	for x := math.MinInt16; x <= math.MaxInt16; x++ {
-		ins.I32FromS16(t.Context(), int16(x))
-	}
-}
-
-func TestS16FromI32(t *testing.T) {
-	fac, err := NewInstructionsFactory(t.Context())
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer fac.Close(t.Context())
-
-	ins, err := fac.Instantiate(t.Context())
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer ins.Close(t.Context())
-
-	actual := ins.S16FromI32(t.Context())
-
-	const expected = 0
-	if actual != expected {
-		t.Errorf("expected: %d, but got: %d", expected, actual)
-	}
-}
-
-func TestI32FromU16(t *testing.T) {
-	fac, err := NewInstructionsFactory(t.Context())
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer fac.Close(t.Context())
-
-	ins, err := fac.Instantiate(t.Context())
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer ins.Close(t.Context())
-
-	for x := 0; x <= math.MaxUint16; x++ {
-		ins.I32FromU16(t.Context(), uint16(x))
-	}
-}
-
-func TestU16FromI32(t *testing.T) {
-	fac, err := NewInstructionsFactory(t.Context())
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer fac.Close(t.Context())
-
-	ins, err := fac.Instantiate(t.Context())
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer ins.Close(t.Context())
-
-	actual := ins.U16FromI32(t.Context())
-
-	const expected = 0
-	if actual != expected {
-		t.Errorf("expected: %d, but got: %d", expected, actual)
+	for expected := 0; expected <= math.MaxUint16; expected++ {
+		actual := ins.U16Roundtrip(t.Context(), uint16(expected))
+		if actual != expected {
+			t.Errorf("expected: %d, but got: %d", expected, actual)
+		}
 	}
 }

--- a/examples/instructions/instructions_test.go
+++ b/examples/instructions/instructions_test.go
@@ -1,12 +1,16 @@
 package instructions
 
 import (
+	"fmt"
 	"iter"
 	"math"
+	"math/rand/v2"
 	"testing"
 )
 
-func inclusive[Num interface { ~int8 | ~uint8 | ~int16 | ~uint16 }](start Num, end Num) iter.Seq[Num] {
+func inclusive[Num interface {
+	~int8 | ~uint8 | ~int16 | ~uint16
+}](start Num, end Num) iter.Seq[Num] {
 	return func(yield func(v Num) bool) {
 		var next Num = start
 		for {
@@ -21,7 +25,7 @@ func inclusive[Num interface { ~int8 | ~uint8 | ~int16 | ~uint16 }](start Num, e
 		}
 	}
 }
-func inclusiveStep[Num interface { ~int32 | ~uint32 }](start Num, end Num, step Num) iter.Seq[Num] {
+func inclusiveStep[Num interface{ ~int32 | ~uint32 }](start Num, end Num, step Num) iter.Seq[Num] {
 	return func(yield func(v Num) bool) {
 		var next Num = start
 		for {
@@ -32,7 +36,7 @@ func inclusiveStep[Num interface { ~int32 | ~uint32 }](start Num, end Num, step 
 				return
 			}
 
-			if end - step > next {
+			if end-step > next {
 				next += step
 			} else {
 				next = end
@@ -164,5 +168,57 @@ func Test_U32Roundtrip(t *testing.T) {
 		if actual != expected {
 			t.Errorf("expected: %d, but got: %d", expected, actual)
 		}
+	}
+}
+
+func Test_F32Roundtrip(t *testing.T) {
+	fac, err := NewInstructionsFactory(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fac.Close(t.Context())
+
+	ins, err := fac.Instantiate(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ins.Close(t.Context())
+
+	// Generate a bunch of random floats and check they all roundtrip correctly.
+	seed := 123456
+	rng := rand.New(rand.NewPCG(uint64(seed), uint64(seed)))
+	for i := range 1000 {
+		t.Run(fmt.Sprintf("i: %d", i), func(t *testing.T) {
+			expected := rng.Float32()
+			if actual := ins.F32Roundtrip(t.Context(), expected); actual != expected {
+				t.Errorf("expected: %f, but got: %f", expected, actual)
+			}
+		})
+	}
+}
+
+func Test_F64Roundtrip(t *testing.T) {
+	fac, err := NewInstructionsFactory(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fac.Close(t.Context())
+
+	ins, err := fac.Instantiate(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ins.Close(t.Context())
+
+	// Generate a bunch of random floats and check they all roundtrip correctly.
+	seed := 123456
+	rng := rand.New(rand.NewPCG(uint64(seed), uint64(seed)))
+	for i := range 1000 {
+		t.Run(fmt.Sprintf("i: %d", i), func(t *testing.T) {
+			expected := rng.Float64()
+			if actual := ins.F64Roundtrip(t.Context(), expected); actual != expected {
+				t.Errorf("expected: %f, but got: %f", expected, actual)
+			}
+		})
 	}
 }

--- a/examples/instructions/instructions_test.go
+++ b/examples/instructions/instructions_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestI32FromS8(t *testing.T) {
-	fac, err := NewBasicFactory(t.Context())
+	fac, err := NewInstructionsFactory(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/examples/instructions/instructions_test.go
+++ b/examples/instructions/instructions_test.go
@@ -1,9 +1,26 @@
 package instructions
 
 import (
+	"iter"
 	"math"
 	"testing"
 )
+
+func inclusive[Num interface { ~int8 | ~uint8 | ~int16 | ~uint16 }](start Num, end Num) iter.Seq[Num] {
+	return func(yield func(v Num) bool) {
+		var next Num = start
+		for {
+			if !yield(next) {
+				return
+			}
+			if next != end {
+				next++
+			} else {
+				return
+			}
+		}
+	}
+}
 
 func Test_S8Roundtrip(t *testing.T) {
 	fac, err := NewInstructionsFactory(t.Context())
@@ -18,8 +35,7 @@ func Test_S8Roundtrip(t *testing.T) {
 	}
 	defer ins.Close(t.Context())
 
-	var expected int8
-	for expected = math.MinInt8; expected <= math.MaxInt8; expected++ {
+	for expected := range inclusive[int8](math.MinInt8, math.MaxInt8) {
 		actual := ins.S8Roundtrip(t.Context(), expected)
 		if actual != expected {
 			t.Errorf("expected: %d, but got: %d", expected, actual)
@@ -40,8 +56,7 @@ func Test_U8Roundtrip(t *testing.T) {
 	}
 	defer ins.Close(t.Context())
 
-	var expected uint8
-	for expected = 0; expected <= math.MaxUint8; expected++ {
+	for expected := range inclusive[uint8](0, math.MaxUint8) {
 		actual := ins.U8Roundtrip(t.Context(), expected)
 		if actual != expected {
 			t.Errorf("expected: %d, but got: %d", expected, actual)
@@ -62,8 +77,7 @@ func Test_S16Roundtrip(t *testing.T) {
 	}
 	defer ins.Close(t.Context())
 
-	var expected int16
-	for expected = math.MinInt16; expected <= math.MaxInt16; expected++ {
+	for expected := range inclusive[int16](math.MaxInt16, math.MaxInt16) {
 		actual := ins.S16Roundtrip(t.Context(), expected)
 		if actual != expected {
 			t.Errorf("expected: %d, but got: %d", expected, actual)
@@ -84,8 +98,7 @@ func Test_U16Roundtrip(t *testing.T) {
 	}
 	defer ins.Close(t.Context())
 
-	var expected uint16
-	for expected = 0; expected <= math.MaxUint16; expected++ {
+	for expected := range inclusive[uint16](0, math.MaxUint16) {
 		actual := ins.U16Roundtrip(t.Context(), expected)
 		if actual != expected {
 			t.Errorf("expected: %d, but got: %d", expected, actual)

--- a/examples/instructions/instructions_test.go
+++ b/examples/instructions/instructions_test.go
@@ -18,8 +18,9 @@ func Test_S8Roundtrip(t *testing.T) {
 	}
 	defer ins.Close(t.Context())
 
-	for expected := math.MinInt8; expected <= math.MaxInt8; expected++ {
-		actual := ins.S8Roundtrip(t.Context(), int8(expected))
+	var expected int8
+	for expected = math.MinInt8; expected <= math.MaxInt8; expected++ {
+		actual := ins.S8Roundtrip(t.Context(), expected)
 		if actual != expected {
 			t.Errorf("expected: %d, but got: %d", expected, actual)
 		}
@@ -39,8 +40,9 @@ func Test_U8Roundtrip(t *testing.T) {
 	}
 	defer ins.Close(t.Context())
 
-	for expected := 0; expected <= math.MaxUint8; expected++ {
-		actual := ins.TestU8Roundtrip(t.Context(), uint8(expected))
+	var expected uint8
+	for expected = 0; expected <= math.MaxUint8; expected++ {
+		actual := ins.TestU8Roundtrip(t.Context(), expected)
 		if actual != expected {
 			t.Errorf("expected: %d, but got: %d", expected, actual)
 		}
@@ -60,8 +62,9 @@ func Test_S16Roundtrip(t *testing.T) {
 	}
 	defer ins.Close(t.Context())
 
-	for expected := math.MinInt16; expected <= math.MaxInt16; expected++ {
-		actual := ins.S16Roundtrip(t.Context(), int16(expected))
+	var expected int16
+	for expected = math.MinInt16; expected <= math.MaxInt16; expected++ {
+		actual := ins.S16Roundtrip(t.Context(), expected)
 		if actual != expected {
 			t.Errorf("expected: %d, but got: %d", expected, actual)
 		}
@@ -81,8 +84,9 @@ func Test_U16Roundtrip(t *testing.T) {
 	}
 	defer ins.Close(t.Context())
 
-	for expected := 0; expected <= math.MaxUint16; expected++ {
-		actual := ins.U16Roundtrip(t.Context(), uint16(expected))
+	var expected uint16
+	for expected = 0; expected <= math.MaxUint16; expected++ {
+		actual := ins.U16Roundtrip(t.Context(), expected)
 		if actual != expected {
 			t.Errorf("expected: %d, but got: %d", expected, actual)
 		}

--- a/examples/instructions/src/lib.rs
+++ b/examples/instructions/src/lib.rs
@@ -13,4 +13,10 @@ impl Guest for InstructionsWorld {
     fn s8_from_i32() -> i8 {
         Default::default()
     }
+    fn i32_from_u8(val: u8) {
+        assert!((u8::MIN..=u8::MAX).contains(&val));
+    }
+    fn u8_from_i32() -> u8 {
+        Default::default()
+    }
 }

--- a/examples/instructions/src/lib.rs
+++ b/examples/instructions/src/lib.rs
@@ -1,0 +1,13 @@
+wit_bindgen::generate!({
+    world: "instructions",
+});
+
+struct InstructionsWorld;
+
+export!(InstructionsWorld);
+
+impl Guest for InstructionsWorld {
+    fn i32_from_s8(val: i8) {
+        assert!((i8::MIN..=i8::MAX).contains(&val));
+    }
+}

--- a/examples/instructions/src/lib.rs
+++ b/examples/instructions/src/lib.rs
@@ -19,4 +19,16 @@ impl Guest for InstructionsWorld {
     fn u8_from_i32() -> u8 {
         Default::default()
     }
+    fn i32_from_s16(val: i16) {
+        assert!((i16::MIN..=i16::MAX).contains(&val));
+    }
+    fn s16_from_i32() -> i16 {
+        Default::default()
+    }
+    fn i32_from_u16(val: u16) {
+        assert!((u16::MIN..=u16::MAX).contains(&val));
+    }
+    fn u16_from_i32() -> u16 {
+        Default::default()
+    }
 }

--- a/examples/instructions/src/lib.rs
+++ b/examples/instructions/src/lib.rs
@@ -10,4 +10,7 @@ impl Guest for InstructionsWorld {
     fn i32_from_s8(val: i8) {
         assert!((i8::MIN..=i8::MAX).contains(&val));
     }
+    fn s8_from_i32() -> i8 {
+        Default::default()
+    }
 }

--- a/examples/instructions/src/lib.rs
+++ b/examples/instructions/src/lib.rs
@@ -7,28 +7,20 @@ struct InstructionsWorld;
 export!(InstructionsWorld);
 
 impl Guest for InstructionsWorld {
-    fn i32_from_s8(val: i8) {
+    fn s8_roundtrip(val: i8) -> i8 {
         assert!((i8::MIN..=i8::MAX).contains(&val));
+        val
     }
-    fn s8_from_i32() -> i8 {
-        Default::default()
-    }
-    fn i32_from_u8(val: u8) {
+    fn u8_roundtrip(val: u8) -> u8 {
         assert!((u8::MIN..=u8::MAX).contains(&val));
+        val
     }
-    fn u8_from_i32() -> u8 {
-        Default::default()
-    }
-    fn i32_from_s16(val: i16) {
+    fn s16_roundtrip(val: i16) -> i16 {
         assert!((i16::MIN..=i16::MAX).contains(&val));
+        val
     }
-    fn s16_from_i32() -> i16 {
-        Default::default()
-    }
-    fn i32_from_u16(val: u16) {
+    fn u16_roundtrip(val: u16) -> u16 {
         assert!((u16::MIN..=u16::MAX).contains(&val));
-    }
-    fn u16_from_i32() -> u16 {
-        Default::default()
+        val
     }
 }

--- a/examples/instructions/src/lib.rs
+++ b/examples/instructions/src/lib.rs
@@ -23,4 +23,12 @@ impl Guest for InstructionsWorld {
         assert!((u16::MIN..=u16::MAX).contains(&val));
         val
     }
+    fn s32_roundtrip(val: i32) -> i32 {
+        assert!((i32::MIN..=i32::MAX).contains(&val));
+        val
+    }
+    fn u32_roundtrip(val: u32) -> u32 {
+        assert!((u32::MIN..=u32::MAX).contains(&val));
+        val
+    }
 }

--- a/examples/instructions/src/lib.rs
+++ b/examples/instructions/src/lib.rs
@@ -31,4 +31,12 @@ impl Guest for InstructionsWorld {
         assert!((u32::MIN..=u32::MAX).contains(&val));
         val
     }
+    fn f32_roundtrip(val: f32) -> f32 {
+        assert!((f32::MIN..=f32::MAX).contains(&val));
+        val
+    }
+    fn f64_roundtrip(val: f64) -> f64 {
+        assert!((f64::MIN..=f64::MAX).contains(&val));
+        val
+    }
 }

--- a/examples/instructions/wit/instructions.wit
+++ b/examples/instructions/wit/instructions.wit
@@ -1,15 +1,11 @@
 package gravity:instructions;
 
 world instructions {
-  export i32-from-s8: func(val: s8);
-  export s8-from-i32: func() -> s8;
+  export s8-roundtrip: func(val: s8) -> s8;
 
-  export i32-from-u8: func(val: u8);
-  export u8-from-i32: func() -> u8;
+  export u8-roundtrip: func(val: u8) -> u8;
 
-  export i32-from-s16: func(val: s16);
-  export s16-from-i32: func() -> s16;
+  export s16-roundtrip: func(val: s16) -> s16;
 
-  export i32-from-u16: func(val: u16);
-  export u16-from-i32: func() -> u16;
+  export u16-roundtrip: func(val: u16) -> u16;
 }

--- a/examples/instructions/wit/instructions.wit
+++ b/examples/instructions/wit/instructions.wit
@@ -3,4 +3,7 @@ package gravity:instructions;
 world instructions {
   export i32-from-s8: func(val: s8);
   export s8-from-i32: func() -> s8;
+
+  export i32-from-u8: func(val: u8);
+  export u8-from-i32: func() -> u8;
 }

--- a/examples/instructions/wit/instructions.wit
+++ b/examples/instructions/wit/instructions.wit
@@ -6,4 +6,10 @@ world instructions {
 
   export i32-from-u8: func(val: u8);
   export u8-from-i32: func() -> u8;
+
+  export i32-from-s16: func(val: s16);
+  export s16-from-i32: func() -> s16;
+
+  export i32-from-u16: func(val: u16);
+  export u16-from-i32: func() -> u16;
 }

--- a/examples/instructions/wit/instructions.wit
+++ b/examples/instructions/wit/instructions.wit
@@ -12,4 +12,8 @@ world instructions {
   export s32-roundtrip: func(val: s32) -> s32;
 
   export u32-roundtrip: func(val: u32) -> u32;
+
+  export f32-roundtrip: func(val: f32) -> f32;
+
+  export f64-roundtrip: func(val: f64) -> f64;
 }

--- a/examples/instructions/wit/instructions.wit
+++ b/examples/instructions/wit/instructions.wit
@@ -2,4 +2,5 @@ package gravity:instructions;
 
 world instructions {
   export i32-from-s8: func(val: s8);
+  export s8-from-i32: func() -> s8;
 }

--- a/examples/instructions/wit/instructions.wit
+++ b/examples/instructions/wit/instructions.wit
@@ -8,4 +8,8 @@ world instructions {
   export s16-roundtrip: func(val: s16) -> s16;
 
   export u16-roundtrip: func(val: u16) -> u16;
+
+  export s32-roundtrip: func(val: s32) -> s32;
+
+  export u32-roundtrip: func(val: u32) -> u32;
 }

--- a/examples/instructions/wit/instructions.wit
+++ b/examples/instructions/wit/instructions.wit
@@ -1,0 +1,5 @@
+package gravity:instructions;
+
+world instructions {
+  export i32-from-s8: func(val: s8);
+}

--- a/examples/outlier/Cargo.toml
+++ b/examples/outlier/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "example-outlier"
+version = "0.0.2"
+edition = "2024"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+augurs-outlier = { git = "https://github.com/grafana/augurs", branch = "rand-0.9", features = ["serde"] }
+getrandom = { version = "0.3" }
+wit-bindgen = "=0.42.1"
+wit-component = "=0.230.0"

--- a/examples/outlier/README.md
+++ b/examples/outlier/README.md
@@ -1,0 +1,40 @@
+# Outlier Detection Wasm Component
+
+This directory contains:
+
+- the interface definition for a Wasm component that can perform outlier detection on time series (see `wit/world.wit`)
+- a Rust crate which exposes augurs' outlier detection functionality as a Wasm component (see `src/lib.rs`)
+- tests for a Go package which can be generated from the Wasm component using [gravity] (see `outlier_test.go`)
+
+The goal is to provide a Go package that can embed some augurs functionality without having to resort to FFI.
+
+## Building
+
+### Prerequisites
+
+- A recent nightly Rust compiler (e.g. `rustup install nightly`)
+- The `wasm32-unknown-unknown` target (`rustup target add wasm32-unknown-unknown`)
+- [Go](https://go.dev/)
+- [gravity](https://github.com/arcjet/gravity)
+- [just](https://just.systems/man/en/)
+
+### Steps
+
+1. Build the Rust crate
+
+   ```sh
+   just build-wasm
+   ```
+
+2. Generate the Go package
+
+   ```sh
+   just gen-go
+   ```
+
+3. Run the Go tests
+
+
+   ```sh
+   just test-go
+   ```

--- a/examples/outlier/justfile
+++ b/examples/outlier/justfile
@@ -1,0 +1,11 @@
+# Build the Rust code.
+build-wasm:
+    RUSTFLAGS='--cfg getrandom_backend="custom"' cargo build --target wasm32-unknown-unknown --release
+
+# Generate the Go code from the Wasm file using Gravity.
+gen-go:
+    go generate
+
+# Test the generated Go code.
+test-go:
+    go test ./...

--- a/examples/outlier/outlier_test.go
+++ b/examples/outlier/outlier_test.go
@@ -1,0 +1,81 @@
+package outlier
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type outlierTypes struct{}
+
+func TestDetect(t *testing.T) {
+	t.Parallel()
+
+	t.Run("dbscan", func(t *testing.T) {
+		ctx := t.Context()
+		f, err := NewOutlierFactory(ctx, outlierTypes{})
+		require.NoError(t, err)
+		t.Cleanup(func() { f.Close(ctx) })
+
+		ins, err := f.Instantiate(ctx)
+		require.NoError(t, err)
+		t.Cleanup(func() { ins.Close(ctx) })
+
+		input := Input{
+			Algorithm: AlgorithmDbscan{
+				EpsilonOrSensitivity: EpsilonOrSensitivitySensitivity(0.5),
+			},
+			Data: [][]float64{
+				{1.0, 2.0, 1.5, 2.3},
+				{1.9, 2.2, 1.2, 2.4},
+				{1.5, 2.1, 6.4, 8.5},
+			},
+		}
+
+		detected, err := ins.Detect(ctx, input)
+		require.NoError(t, err)
+
+		assert.Len(t, detected.OutlyingSeries, 1)
+		assert.Contains(t, detected.OutlyingSeries, uint32(2))
+		assert.True(t, detected.SeriesResults[2].IsOutlier)
+		assert.Equal(t, []float64{0.0, 0.0, 1.0, 1.0}, detected.SeriesResults[2].Scores)
+		assert.NotNil(t, detected.ClusterBand)
+	})
+
+	t.Run("mad", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		f, err := NewOutlierFactory(ctx, outlierTypes{})
+		require.NoError(t, err)
+		t.Cleanup(func() { f.Close(ctx) })
+
+		ins, err := f.Instantiate(ctx)
+		require.NoError(t, err)
+		t.Cleanup(func() { ins.Close(ctx) })
+
+		input := Input{
+			Algorithm: AlgorithmMad{
+				ThresholdOrSensitivity: ThresholdOrSensitivitySensitivity(0.5),
+			},
+			Data: [][]float64{
+				{31.6},
+				{33.12},
+				{33.84},
+				{38.234}, // outlier
+				{12.83},
+				{15.23},
+				{33.23},
+				{32.85},
+				{24.72},
+			},
+		}
+		detected, err := ins.Detect(ctx, input)
+		require.NoError(t, err)
+
+		assert.Len(t, detected.OutlyingSeries, 1)
+		assert.Contains(t, detected.OutlyingSeries, uint32(3))
+		assert.True(t, detected.SeriesResults[3].IsOutlier)
+		assert.NotNil(t, detected.ClusterBand)
+	})
+}

--- a/examples/outlier/src/lib.rs
+++ b/examples/outlier/src/lib.rs
@@ -1,0 +1,163 @@
+#![doc = include_str!("../README.md")]
+
+use std::fmt;
+
+use augurs_outlier::{DbscanDetector, MADDetector, OutlierDetector};
+use getrandom::Error;
+
+// It looks like some dependency or other is importing getrandom despite not actually
+// using it, so we can just provide a dummy implementation here.
+// If we see errors later we could try to import a RNG source via the Component Model.
+// See https://docs.rs/getrandom/latest/getrandom/#custom-backend for info on this.
+#[unsafe(no_mangle)]
+unsafe extern "Rust" fn __getrandom_v03_custom(_dest: *mut u8, _len: usize) -> Result<(), Error> {
+    Err(Error::UNSUPPORTED)
+}
+
+// Wrap the wit-bindgen macro in a module so we don't get warned about missing docs in the generated trait.
+mod bindings {
+    wit_bindgen::generate!({
+        world: "outlier",
+        default_bindings_module: "bindings",
+    });
+}
+use bindings::{
+    Guest,
+    augurs::outlier::types::{
+        Algorithm, Band, EpsilonOrSensitivity, Input, OutlierInterval, Output, Series,
+        ThresholdOrSensitivity,
+    },
+    export,
+};
+
+struct OutlierWorld;
+export!(OutlierWorld);
+
+impl Guest for OutlierWorld {
+    fn detect(input: Input) -> Result<Output, String> {
+        detect(input).map_err(|e| e.to_string())
+    }
+}
+
+// #[derive(Debug, Deserialize)]
+// #[serde(untagged, rename_all = "camelCase")]
+// enum Algorithm {
+//     Dbscan(DbscanParams),
+//     Mad(MadParams),
+// }
+
+// #[derive(Debug, Deserialize)]
+// #[serde(rename_all = "camelCase")]
+// struct DbscanParams {
+//     epsilon_or_sensitivity: EpsilonOrSensitivity,
+// }
+
+// #[derive(Debug, Deserialize)]
+// #[serde(rename_all = "camelCase")]
+// enum EpsilonOrSensitivity {
+//     Sensitivity(f64),
+//     Epsilon(f64),
+// }
+
+// #[derive(Debug, Deserialize)]
+// #[serde(rename_all = "camelCase")]
+// struct MadParams {
+//     threshold_or_sensitivity: ThresholdOrSensitivity,
+// }
+
+// #[derive(Debug, Deserialize)]
+// #[serde(rename_all = "camelCase")]
+// enum ThresholdOrSensitivity {
+//     Sensitivity(f64),
+//     Threshold(f64),
+// }
+
+// #[derive(Debug, Deserialize)]
+// #[serde(rename_all = "lowercase")]
+// struct Input {
+//     algorithm: Algorithm,
+//     data: Vec<Vec<f64>>,
+// }
+
+#[derive(Debug)]
+enum TypedError {
+    InvalidSensitivity(augurs_outlier::Error),
+    TryFromIntError(std::num::TryFromIntError),
+}
+
+impl From<augurs_outlier::Error> for TypedError {
+    fn from(value: augurs_outlier::Error) -> Self {
+        Self::InvalidSensitivity(value)
+    }
+}
+
+impl From<std::num::TryFromIntError> for TypedError {
+    fn from(value: std::num::TryFromIntError) -> Self {
+        Self::TryFromIntError(value)
+    }
+}
+
+impl fmt::Display for TypedError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidSensitivity(e) => write!(f, "invalid sensitivity: {}", e),
+            Self::TryFromIntError(e) => write!(f, "overflow converting to u32: {}", e),
+        }
+    }
+}
+
+impl std::error::Error for TypedError {}
+
+fn detect(input: Input) -> Result<Output, TypedError> {
+    let data_ref: Vec<_> = input.data.iter().map(|v| v.as_slice()).collect();
+    let output = match input.algorithm {
+        Algorithm::Dbscan(params) => {
+            let detector = match params.epsilon_or_sensitivity {
+                EpsilonOrSensitivity::Sensitivity(s) => DbscanDetector::with_sensitivity(s)?,
+                EpsilonOrSensitivity::Epsilon(e) => DbscanDetector::with_epsilon(e),
+            };
+            let preprocessed = detector.preprocess(&data_ref)?;
+            detector.detect(&preprocessed)?
+        }
+        Algorithm::Mad(params) => {
+            let detector = match params.threshold_or_sensitivity {
+                ThresholdOrSensitivity::Sensitivity(s) => MADDetector::with_sensitivity(s)?,
+                ThresholdOrSensitivity::Threshold(t) => MADDetector::with_threshold(t),
+            };
+            let preprocessed = detector.preprocess(&data_ref)?;
+            detector.detect(&preprocessed)?
+        }
+    };
+    Ok(Output {
+        outlying_series: output
+            .outlying_series
+            .into_iter()
+            .map(TryInto::<u32>::try_into)
+            .collect::<Result<_, _>>()?,
+        series_results: output
+            .series_results
+            .into_iter()
+            .map(|series| {
+                Ok(Series {
+                    is_outlier: series.is_outlier,
+                    outlier_intervals: series
+                        .outlier_intervals
+                        .intervals
+                        .into_iter()
+                        .map(|interval| {
+                            Ok(OutlierInterval {
+                                start: interval.start.try_into()?,
+                                end: interval.end.map(TryInto::try_into).transpose()?,
+                            })
+                        })
+                        .collect::<Result<_, TypedError>>()?,
+                    scores: series.scores,
+                })
+            })
+            .collect::<Result<_, TypedError>>()?,
+        cluster_band: output.cluster_band.map(|band| Band {
+            min: band.min,
+            max: band.max,
+        }),
+    })
+}

--- a/examples/outlier/wit/world.wit
+++ b/examples/outlier/wit/world.wit
@@ -1,0 +1,142 @@
+/// The outlier detector world.
+package augurs:outlier;
+
+// TODO: uncomment and use when Gravity supports user defined complex types.
+/// Types used by the outlier detector world.
+interface types {
+    /// The input for the outlier detector.
+    ///
+    /// Currently this is represented as a string because Gravity
+    /// does not yet support more complex types.
+    ///
+    /// It should be a JSON object with the following fields:
+    record input {
+        /// The data to detect outliers in.
+        data: list<list<f64>>,
+
+        /// The algorithm to use, with the params.
+        algorithm: algorithm,
+    }
+
+    /// The output of an outlier detector
+    record output {
+        /// The indexes of the series considered outliers.
+        ///
+        /// This is a `BTreeSet` to ensure that the order of the series is preserved.
+        outlying-series: list<u32>,
+
+        /// The results of the detection for each series.
+        series-results: list<series>,
+
+        /// The band indicating the min and max value considered outlying
+        /// at each timestamp.
+        ///
+        /// This may be `None` if no cluster was found (for example if
+        /// there were fewer than 3 series in the input data in the case of
+        /// DBSCAN).
+        cluster-band: option<band>,
+    }
+
+    /// A potentially outlying series.
+    record series {
+        /// Whether the series is an outlier for at least one of the samples.
+        is-outlier: bool,
+        /// The intervals of the samples that are considered outliers.
+        outlier-intervals: list<outlier-interval>,
+        /// The outlier scores of the series for each sample.
+        ///
+        /// The higher the score, the more likely the series is an outlier.
+        /// Note that some implementations may not provide continuous scores
+        /// but rather a binary classification. In this case, the scores will
+        /// be 0.0 for non-outliers and 1.0 for outliers.
+        scores: list<f64>,
+    }
+
+    /// A single outlier interval.
+    ///
+    /// An outlier interval is a contiguous range of indices in a time series
+    /// where an outlier is detected.
+    record outlier-interval {
+        /// The start index of the interval.
+        start: u32,
+        /// The end index of the interval, if it exists.
+        ///
+        /// If the interval is open-ended, this will be `None`.
+        end: option<u32>,
+    }
+
+    /// A band indicating the min and max value considered outlying
+    /// at each timestamp.
+    record band {
+        /// The minimum value considered outlying at each timestamp.
+        min: list<f64>,
+        /// The maximum value considered outlying at each timestamp.
+        max: list<f64>,
+    }
+
+    /// Errors that can occur during outlier detection.
+    ///
+    /// Currently this is represented as a string because Gravity
+    /// does not yet support more complex types.
+    type error = string;
+
+    /// The epsilon or sensitivity parameter for the DBSCAN algorithm.
+    variant epsilon-or-sensitivity {
+        /// A scale-invariant sensitivity parameter.
+        ///
+        /// This must be in (0, 1) and will be used to estimate a sensible
+        /// value of epsilon based on the data at detection-time.
+        sensitivity(f64),
+        /// The maximum distance between points in a cluster.
+        epsilon(f64),
+    }
+
+    /// The parameters for the DBSCAN algorithm.
+    record dbscan-params {
+        /// Either the epsilon or sensitivity for the algorithm.
+        epsilon-or-sensitivity: epsilon-or-sensitivity,
+    }
+
+    /// Either a scale-invariant sensitivity parameter or a threshold.
+    variant threshold-or-sensitivity {
+        /// A scale-invariant sensitivity parameter.
+        ///
+        /// This must be in (0, 1) and will be used to estimate a sensible
+        /// threshold at detection-time.
+        sensitivity(f64),
+        /// The threshold above which points are considered anomalous.
+        threshold(f64),
+    }
+
+    /// The parameters for the MAD algorithm.
+    record mad-params {
+        /// Either the threshold or sensitivity for the algorithm.
+        threshold-or-sensitivity: threshold-or-sensitivity,
+    }
+
+    /// The algorithm to use for outlier detection.
+    variant algorithm {
+        /// The DBSCAN algorithm.
+        ///
+        /// This algorithm is a density-based algorithm that uses a
+        /// clustering algorithm to group together points that are
+        /// close to each other.
+        dbscan(dbscan-params),
+
+        /// The MAD algorithm.
+        ///
+        /// This algorithm is a density-based algorithm that uses a
+        /// clustering algorithm to group together points that are
+        /// close to each other.
+        mad(mad-params),
+    }
+}
+
+/// The outlier detector world.
+world outlier {
+    // export types;
+    use types.{input, output};
+
+    /// Detect outliers in the input.
+    export detect: func(input: input) -> result<output, string>;
+}

--- a/examples/records/Cargo.toml
+++ b/examples/records/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "example-records"
+version = "0.0.2"
+edition = "2024"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = "=0.42.1"
+wit-component = "=0.230.0"

--- a/examples/records/records_test.go
+++ b/examples/records/records_test.go
@@ -1,0 +1,66 @@
+package records
+
+import (
+	"math"
+	"testing"
+)
+
+type types struct{}
+
+func TestRecord(t *testing.T) {
+	tys := types{}
+	fac, err := NewRecordsFactory(t.Context(), tys)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fac.Close(t.Context())
+
+	ins, err := fac.Instantiate(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ins.Close(t.Context())
+
+	foo := Foo{
+		Float32: 1.0,
+		Float64: 1.0,
+		Uint32:  1,
+		Uint64:  uint64(math.MaxUint32),
+		S:       "hello",
+		Vf32:    []float32{1.0, 2.0, 3.0},
+		Vf64:    []float64{1.0, 2.0, 3.0},
+	}
+	got := ins.ModifyFoo(t.Context(), foo)
+	want := Foo{
+		Float32: foo.Float32 * 2.0,
+		Float64: foo.Float64 * 2.0,
+		Uint32:  foo.Uint32 + 1,
+		Uint64:  foo.Uint64 + 1,
+		S:       "received hello",
+		Vf32:    []float32{2.0, 4.0, 6.0},
+		Vf64:    []float64{2.0, 4.0, 6.0},
+	}
+	if !fooCmp(got, want) {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+}
+
+func fooCmp(a, b Foo) bool {
+	if a.Float32 != b.Float32 || a.Float64 != b.Float64 || a.Uint32 != b.Uint32 || a.Uint64 != b.Uint64 || a.S != b.S {
+		return false
+	}
+	if len(a.Vf32) != len(b.Vf32) || len(a.Vf64) != len(b.Vf64) {
+		return false
+	}
+	for i := range a.Vf32 {
+		if a.Vf32[i] != b.Vf32[i] {
+			return false
+		}
+	}
+	for i := range a.Vf64 {
+		if a.Vf64[i] != b.Vf64[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/examples/records/src/lib.rs
+++ b/examples/records/src/lib.rs
@@ -1,0 +1,31 @@
+wit_bindgen::generate!({
+    world: "records",
+});
+
+struct RecordsWorld;
+
+export!(RecordsWorld);
+
+impl Guest for RecordsWorld {
+    fn modify_foo(
+        Foo {
+            float64,
+            float32,
+            uint32,
+            uint64,
+            s,
+            vf32,
+            vf64,
+        }: Foo,
+    ) -> Foo {
+        Foo {
+            float64: float64 * 2.0,
+            float32: float32 * 2.0,
+            uint32: uint32 + 1,
+            uint64: uint64 + 1,
+            s: format!("received {s}"),
+            vf32: vf32.iter().map(|v| v * 2.0).collect(),
+            vf64: vf64.iter().map(|v| v * 2.0).collect(),
+        }
+    }
+}

--- a/examples/records/wit/records.wit
+++ b/examples/records/wit/records.wit
@@ -1,0 +1,18 @@
+package arcjet:records;
+
+interface types {
+  record foo {
+    float32: f32,
+    float64: f64,
+    uint32: u32,
+    uint64: u64,
+    s: string,
+    vf32: list<f32>,
+    vf64: list<f64>,
+  }
+}
+
+world records {
+  use types.{foo};
+  export modify-foo: func(f: foo) -> foo;
+}

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,13 @@ go 1.24.3
 require github.com/tetratelabs/wazero v1.9.0
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.11.1 // indirect
 	golang.org/x/mod v0.24.0 // indirect
 	golang.org/x/sync v0.14.0 // indirect
 	golang.org/x/tools v0.33.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 tool golang.org/x/tools/cmd/goimports

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,9 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/tetratelabs/wazero v1.9.0 h1:IcZ56OuxrtaEz8UYNRHBrUa9bYeX9oVY93KspZZBf/I=
 github.com/tetratelabs/wazero v1.9.0/go.mod h1:TSbcXCfFP0L2FGkRPxHphadXPjo1T6W+CseNNY7EkjM=
 golang.org/x/mod v0.24.0 h1:ZfthKaKaT4NrhGVZHO1/WDTwGES4De8KtWO0SIbNJMU=
@@ -6,3 +12,6 @@ golang.org/x/sync v0.14.0 h1:woo0S4Yywslg6hp4eUFjTVOyKt0RookbpAHG4c1HmhQ=
 golang.org/x/sync v0.14.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/tools v0.33.0 h1:4qz2S3zmRxbGIhDIAgjxvFutSvH5EfnsYrRBj0UI0bc=
 golang.org/x/tools v0.33.0/go.mod h1:CIJMaWEY88juyUfo7UbgPqbC8rU2OqfAV1h2Qp0oMYI=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/justfile
+++ b/justfile
@@ -8,16 +8,12 @@ default:
 build:
     cargo build --release
 
-# Run all tests (unit tests + UI tests)
-test: test-unit test-ui
+# Run all tests
+test: test-unit
 
 # Run unit tests
 test-unit:
     cargo test --workspace
-
-# Run UI tests
-test-ui:
-    cargo test --test ui
 
 # Test all examples
 test-examples: build

--- a/justfile
+++ b/justfile
@@ -1,0 +1,60 @@
+#!/usr/bin/env just
+
+# Default recipe - show available commands
+default:
+    @just --list
+
+# Build the gravity binary
+build:
+    cargo build --release
+
+# Run all tests (unit tests + UI tests)
+test: test-unit test-ui
+
+# Run unit tests
+test-unit:
+    cargo test --workspace
+
+# Run UI tests
+test-ui:
+    cargo test --test ui
+
+# Test all examples
+test-examples: build
+    @echo "Building and generating bindings for all examples..."
+    cd examples && go generate ./...
+    @echo "Running tests for all examples..."
+    cd examples && go test ./...
+    @echo "✅ All example tests passed!"
+
+# Clean build artifacts
+clean:
+    cargo clean
+
+# Run linting
+lint:
+    cargo clippy --workspace -- -D warnings
+    cargo fmt --check
+
+# Format code
+fmt:
+    cargo fmt
+
+# Watch for changes and run tests
+watch:
+    cargo watch -x test -x "test --test ui"
+
+# Initialize crates structure (for refactoring)
+init-crates:
+    mkdir -p crates/gravity-go/src
+    mkdir -p crates/gravity-go/tests
+    mkdir -p crates/gravity-codegen/src
+    mkdir -p crates/gravity-codegen/tests
+    mkdir -p crates/gravity-wit/src
+    mkdir -p crates/gravity-wit/tests
+    mkdir -p cmd/gravity/src
+    mkdir -p cmd/gravity/tests/integration
+
+# Run full CI pipeline
+ci: fmt lint test test-examples
+    @echo "✅ CI pipeline complete!"


### PR DESCRIPTION
This rather large, WIP PR is an attempt to refactor the large `main.rs` into several smaller crates with more specific responsibilities:

- `gravity-wit` - reading WASM and WIT
- `gravity-go` - modeling Go language constructs
- `gravity-codegen` - generating Go code

This means they can be modularized, unit tested and extended more easily than hacking on the large main.rs file.

I didn't intend to add any functionality here, but it is based on a branch that's further ahead than `arcjet/gravity:main` because I wanted some more comprehensive tests :grimacing: I'm sure that can be tidied up though.

I'll keep hacking away at this until it works properly, then we can tidy it up if it's something you like the look of.